### PR TITLE
feat: redesign visual layer of CV site

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CV</title>
+  <title>Stephan Teig</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Open+Sans:wght@300;400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@1&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 
   <!-- ============================================================
        ✏️  REDIGER ALT HER — ingen annen fil trenger å endres
@@ -25,25 +25,22 @@
     bilde: "Media/IMG_3340.JPG",
     cvPdf: "Media/StephanTeigCV.pdf",
 
-    // Kontaktskjema — se guide nedenfor for å sette opp Formspree.
-    // Lim inn din Formspree-ID her, f.eks. "xpwzgkla"
-    // Sett til null for å skjule skjemaet.
     formspreeId: "mwvrraez",
 
     bio: {
-      no: "17 år gammel medieelev ved Glemmen VGS. Aktiv med kampsport, ungdomstrener, styreleder og kreativ produsent. Trives i felt med kameraet og liker å omsette visjoner til levende historier.",
-      en: "17-year-old media student at Glemmen VGS. Active in martial arts, youth coach, board chair and creative producer. Thrives in the field with a camera and loves turning visions into living stories.",
+      no: "Fyller 18 den 9. juni 2026. VG2 Medieproduksjon på Glemmen VGS og lærling hos Studio Wallin i Fredrikstad — der jeg jobber med foto, video, brand og podkast frem til sommeren 2028. Lager kortfilmer, fargekorrigerer, designer verktøy og instruerer Ju-Jitsu. Trives best når kamera, kode og historiefortelling overlapper.",
+      en: "Turning 18 on June 9, 2026. VG2 Media Production at Glemmen VGS and apprentice at Studio Wallin in Fredrikstad — working across photo, video, brand and podcast through summer 2028. I make short films, grade colour, build tools, and teach Ju-Jitsu. Best when camera, code and storytelling overlap.",
     },
 
     fraser: {
-      no: [ "kortfilmer.", "innhold som engasjerer.", "historier med kameraet." ],
-      en: [ "short films.", "engaging content.", "stories through the lens." ],
+      no: [ "kortfilmer.", "fargegradering.", "innhold som engasjerer.", "verktøy som hjelper." ],
+      en: [ "short films.", "colour grades.", "engaging content.", "tools that help." ],
     },
 
     stats: [
-      { tall: "7+",    label: { no: "Års jobberfaring", en: "Years work experience" } },
-      { tall: "10+",   label: { no: "Prosjekter",       en: "Projects"              } },
-      { tall: "1.dan", label: { no: "Jiu-Jitsu",        en: "Jiu-Jitsu"            } },
+      { tall: "7+",    label: { no: "Års jobberfaring", en: "Years experience" } },
+      { tall: "15+",   label: { no: "Prosjekter",       en: "Projects"         } },
+      { tall: "1.dan", label: { no: "Jiu-Jitsu",        en: "Jiu-Jitsu"       } },
     ],
 
     // ── NAVIGASJON ───────────────────────────────────────────────
@@ -56,12 +53,13 @@
 
     // ── FERDIGHETER ──────────────────────────────────────────────
     ferdigheter: [
-      { navn: { no: "Kamera & filming",  en: "Camera & filming" }, prosent: 90 },
-      { navn: { no: "Videoredigering",   en: "Video editing"    }, prosent: 85 },
-      { navn: "DaVinci Resolve",                                   prosent: 85 },
-      { navn: { no: "Sosiale medier",    en: "Social media"     }, prosent: 80 },
-      { navn: "Premiere Pro",                                      prosent: 70 },
-      { navn: { no: "Fotografi",         en: "Photography"      }, prosent: 70 },
+      { navn: { no: "Kamera & filming",   en: "Camera & filming"   }, prosent: 90 },
+      { navn: { no: "Videoredigering",    en: "Video editing"      }, prosent: 88 },
+      { navn: "DaVinci Resolve",                                      prosent: 90 },
+      { navn: { no: "Fargegradering",     en: "Colour grading"     }, prosent: 85 },
+      { navn: { no: "Lyddesign",          en: "Sound design"       }, prosent: 75 },
+      { navn: { no: "Innholdsproduksjon", en: "Content production" }, prosent: 85 },
+      { navn: { no: "Fotografi",          en: "Photography"        }, prosent: 70 },
     ],
 
     // ── SPRÅK ────────────────────────────────────────────────────
@@ -82,9 +80,12 @@
     erfaring: [
       {
         aar:    "2025 –",
-        tittel: { no: "Sosiale medier & innholdsproduksjon", en: "Social media & content production" },
+        tittel: { no: "Lærling — foto, video & brand", en: "Apprentice — photo, video & brand" },
         sted:   "Studio Wallin AS · Fredrikstad",
-        tekst:  { no: "Produksjon og publisering av innhold for Instagram og andre plattformer.", en: "Producing and publishing content for Instagram and other platforms." },
+        tekst:  {
+          no: "Foto, videoproduksjon, brand-arbeid og podkast-workflow for kunder inkl. HYSJ, Purply og Installatøren. Formelt lærling innen 31. august 2026, i praksis allerede aktiv.",
+          en: "Photo, video production, brand work and podcast workflow for clients incl. HYSJ, Purply and Installatøren. Formally apprentice by 31 August 2026, already active in practice.",
+        },
       },
       {
         aar:    "2024 –",
@@ -141,7 +142,7 @@
       {
         aar:    "2025 –",
         tittel: { no: "Styreleder", en: "Board chair" },
-        sted:   { no: "Ungdomsstyret, Sentrum Kampsport", en: "Youth board, Sentrum Kampsport" },
+        sted:   { no: "Ungdomsstyret, Sentrum Kampsport (SKS)", en: "Youth board, Sentrum Kampsport (SKS)" },
         tekst:  { no: "Leder ungdomsstyret ved Sentrum Kampsport.", en: "Leading the youth board at Sentrum Kampsport." },
       },
       {
@@ -194,8 +195,8 @@
 
     // ── PROSJEKTER ───────────────────────────────────────────────
     // type: "youtube" | "drive" | "ingen"
-    // embed: YouTube-ID eller Google Drive fil-ID
-    // tekst (valgfri): kort beskrivelse som vises på kortet
+    // badge: true  → vis "// in development"-chip
+    // lenke / github: eksterne lenker for tech-prosjekter
     prosjekter: [
       {
         tittel: "Et ekko av henne",
@@ -240,34 +241,60 @@
         embed:  "y0vjikf5EI8",
         filter: "film",
       },
+      {
+        tittel: "Trace",
+        rolle:  { no: "SVG logo-animatør", en: "SVG logo animator" },
+        tekst:  { no: "Next.js 15 + TypeScript. Animer logoer fra SVG-filer med justerbar hastighet og stil.", en: "Next.js 15 + TypeScript. Animate logos from SVG files with adjustable speed and style." },
+        type:   "ingen",
+        filter: "tech",
+        lenke:  "https://stephanteig.github.io/logo-animator/",
+        github: "https://github.com/stephanteig/logo-animator",
+      },
+      {
+        tittel: "Shotlist Planner",
+        rolle:  { no: "Produksjonsverktøy", en: "Production tool" },
+        tekst:  { no: "Planleggingsverktøy for filmopptak. Under aktiv utvikling — migrerer til Azure.", en: "Shot planning tool for film productions. Under active development — migrating to Azure." },
+        type:   "ingen",
+        filter: "tech",
+        badge:  true,
+      },
+      {
+        tittel: "Color Preview",
+        rolle:  { no: "Obsidian-plugin", en: "Obsidian plugin" },
+        tekst:  { no: "Publisert Obsidian-plugin for forhåndsvisning av farger i notater. PR #12013.", en: "Published Obsidian plugin for colour preview in notes. PR #12013." },
+        type:   "ingen",
+        filter: "tech",
+      },
     ],
 
     // ── UI-TEKSTER ───────────────────────────────────────────────
     ui: {
-      lastNedCV:           { no: "Last ned CV",      en: "Download CV"      },
-      kontaktTittel:       { no: "Kontakt",           en: "Contact"          },
-      ferdigheterTittel:   { no: "Ferdigheter",       en: "Skills"           },
-      sprakTittel:         { no: "Språk",             en: "Languages"        },
-      folgMeg:             { no: "Følg meg",          en: "Follow me"        },
-      heiJegEr:            { no: "Hei, jeg er",       en: "Hi, I'm"          },
-      jegLager:            { no: "Jeg lager",         en: "I create"         },
-      seProsjekter:        { no: "Se prosjekter",     en: "View projects"    },
-      kontaktMeg:          { no: "Kontakt meg",       en: "Contact me"       },
-      erfaring:            { no: "Erfaring",          en: "Experience"       },
-      verv:                { no: "Verv & engasjement",en: "Roles & engagement"},
-      utdanning:           { no: "Utdanning",         en: "Education"        },
-      alle:                { no: "Alle",              en: "All"              },
-      kommerSnart:         { no: "Kommer snart",      en: "Coming soon"      },
-      kontaktSideTittel:   { no: "Send en melding",   en: "Send a message"   },
-      navnPlaceholder:     { no: "Navn",              en: "Name"             },
-      epostPlaceholder:    { no: "E-post",            en: "Email"            },
-      emnePlaceholder:     { no: "Emne",              en: "Subject"          },
-      meldingPlaceholder:  { no: "Melding...",        en: "Message..."       },
-      sendKnapp:           { no: "Send melding",      en: "Send message"     },
-      senderMelding:       { no: "Sender...",         en: "Sending..."       },
-      meldingSendt:        { no: "Melding sendt! Takk.", en: "Message sent! Thanks." },
+      lastNedCV:           { no: "Last ned CV",             en: "Download CV"                  },
+      kontaktTittel:       { no: "Kontakt",                  en: "Contact"                      },
+      ferdigheterTittel:   { no: "Ferdigheter",              en: "Skills"                       },
+      sprakTittel:         { no: "Språk",                    en: "Languages"                    },
+      folgMeg:             { no: "Følg meg",                 en: "Follow me"                    },
+      heroLabel:           { no: "// film + code",           en: "// film + code"               },
+      jegLager:            { no: "Jeg lager",                en: "I create"                     },
+      seProsjekter:        { no: "Se prosjekter",            en: "View projects"                },
+      kontaktMeg:          { no: "Kontakt meg",              en: "Contact me"                   },
+      erfaring:            { no: "Erfaring",                 en: "Experience"                   },
+      verv:                { no: "Verv & engasjement",       en: "Roles & engagement"           },
+      utdanning:           { no: "Utdanning",                en: "Education"                    },
+      alle:                { no: "alle",                     en: "all"                          },
+      kommerSnart:         { no: "// in development",        en: "// in development"            },
+      contactHeadline:     { no: "Direkte linje.",           en: "Reach the studio."            },
+      contactSub:          { no: "Stephan Teig · Fredrikstad, Norge", en: "Stephan Teig · Fredrikstad, Norway" },
+      kontaktSideTittel:   { no: "Send en melding",          en: "Send a message"               },
+      navnPlaceholder:     { no: "Navn",                     en: "Name"                         },
+      epostPlaceholder:    { no: "E-post",                   en: "Email"                        },
+      emnePlaceholder:     { no: "Emne",                     en: "Subject"                      },
+      meldingPlaceholder:  { no: "Melding...",               en: "Message..."                   },
+      sendKnapp:           { no: "Send melding",             en: "Send message"                 },
+      senderMelding:       { no: "Sender...",                en: "Sending..."                   },
+      meldingSendt:        { no: "Melding sendt! Takk.",     en: "Message sent! Thanks."        },
       meldingFeil:         { no: "Noe gikk galt. Prøv igjen.", en: "Something went wrong. Please try again." },
-      skjemaMangler:       { no: "Fyll inn alle feltene.", en: "Please fill in all fields." },
+      skjemaMangler:       { no: "Fyll inn alle feltene.",   en: "Please fill in all fields."   },
       ingenFormspree:      { no: "Kontaktskjema ikke satt opp ennå.", en: "Contact form not set up yet." },
       kortLabels: {
         epost:    { no: "E-post",   en: "Email"    },
@@ -279,270 +306,368 @@
     },
 
     // ── DESIGN ───────────────────────────────────────────────────
-    aksent: "#c8a96e",
+    aksent: "#7c5cfc",
   };
   </script>
 
   <style>
     :root {
-      --bg:      #111111;
-      --sidebar: #0d0d0d;
-      --card:    #161616;
-      --border:  #1f1f1f;
-      --text:    #dddddd;
-      --muted:   #666666;
-      --accent:  #c8a96e;
-      --font-h:  'Montserrat', sans-serif;
-      --font-b:  'Open Sans', sans-serif;
-      --sb:      260px;
-      --nav-h:   38px;
+      --bg:    #0b0b0f;
+      --bg-r:  #111118;
+      --bg-s:  #16161f;
+      --bd:    #1e1e2a;
+      --bd-ui: #2a2a3a;
+      --text:  #f0f0f5;
+      --muted: #8888a8;
+      --dim:   #52526a;
+      --av:    #7c5cfc;
+      --ap:    #d44fa8;
+      --ac:    #4ae3d1;
+      --ag:    rgba(124,92,252,.14);
+      --sb:    280px;
+      --nav-h: 44px;
+      --fd:    'Instrument Serif', serif;
+      --fb:    'Inter', sans-serif;
+      --fm:    'JetBrains Mono', monospace;
     }
 
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html { height: 100%; }
-    body { font-family: var(--font-b); background: var(--bg); color: var(--text); height: 100%; overflow: hidden; }
+    body {
+      font-family: var(--fb);
+      background: var(--bg);
+      color: var(--text);
+      height: 100%;
+      overflow: hidden;
+    }
+    /* Grain texture overlay */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
+      opacity: 0.035;
+      mix-blend-mode: overlay;
+    }
     a { color: inherit; text-decoration: none; }
-
-    .app { display: flex; height: 100vh; width: 100vw; overflow: hidden; }
+    .app { display: flex; height: 100vh; width: 100vw; overflow: hidden; position: relative; z-index: 1; }
 
     /* ── Sidebar ── */
     .sb {
       width: var(--sb); min-width: var(--sb);
-      background: var(--sidebar); border-right: 1px solid var(--border);
+      background: var(--bg-r); border-right: 1px solid var(--bd);
       display: flex; flex-direction: column;
       height: 100vh; overflow-y: auto; overflow-x: hidden; flex-shrink: 0;
     }
-    .sb-top { padding: 1.75rem 1.5rem 1.25rem; text-align: center; border-bottom: 1px solid var(--border); flex-shrink: 0; }
+    .sb-top {
+      padding: 2rem 1.5rem 1.5rem; text-align: center;
+      border-bottom: 1px solid var(--bd); flex-shrink: 0;
+      background: linear-gradient(180deg, rgba(124,92,252,.08) 0%, transparent 100%);
+    }
     .sb-avatar {
-      width: 90px; height: 90px; border-radius: 50%;
-      background: #1a1a1a; border: 2px solid var(--border);
-      margin: 0 auto .85rem;
+      width: 96px; height: 96px; border-radius: 50%;
+      background: var(--bg-s);
+      border: 2px solid var(--av);
+      box-shadow: 0 0 0 5px var(--ag);
+      margin: 0 auto 1rem;
       display: flex; align-items: center; justify-content: center;
-      font-family: var(--font-h); font-size: 26px; font-weight: 700; color: #333;
+      font-family: var(--fb); font-size: 28px; font-weight: 700; color: var(--dim);
       overflow: hidden; flex-shrink: 0;
     }
-    /* FIX: object-position 20% from top so face shows correctly in circle */
     .sb-avatar img { width: 100%; height: 100%; object-fit: cover; object-position: center 20%; }
-    .sb-name  { font-family: var(--font-h); font-size: 15px; font-weight: 700; color: #f0f0f0; letter-spacing: .02em; margin-bottom: .2rem; }
-    .sb-role  { font-size: 8.5px; letter-spacing: .16em; text-transform: uppercase; color: var(--muted); margin-bottom: .9rem; }
+    .sb-name { font-family: var(--fb); font-size: 15px; font-weight: 700; color: var(--text); letter-spacing: .01em; margin-bottom: .25rem; }
+    .sb-role { font-family: var(--fm); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); margin-bottom: 1rem; }
     .sb-download {
       display: inline-block;
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .14em; text-transform: uppercase;
-      padding: .4rem 1rem; border: 1px solid var(--accent); color: var(--accent);
-      border-radius: 2px; cursor: pointer; transition: background .2s, color .2s;
+      font-family: var(--fm); font-size: 9px; letter-spacing: .1em; text-transform: uppercase;
+      padding: .45rem 1.1rem; border: 1px solid var(--av); color: var(--av);
+      border-radius: 4px; cursor: pointer; transition: background .2s, color .2s;
     }
-    .sb-download:hover { background: var(--accent); color: #111; }
-    .sb-body { padding: 1.25rem 1.5rem; flex: 1; overflow-y: auto; }
-    .sb-sec { margin-bottom: 1.5rem; }
+    .sb-download:hover { background: var(--av); color: #fff; }
+    .sb-body { padding: 1.5rem 1.25rem; flex: 1; overflow-y: auto; }
+    .sb-sec { margin-bottom: 1.75rem; }
     .sb-sec-title {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .18em; text-transform: uppercase;
-      color: var(--accent); margin-bottom: .75rem; padding-bottom: .35rem; border-bottom: 1px solid var(--border);
+      font-family: var(--fm); font-size: 9px; letter-spacing: .16em; text-transform: uppercase;
+      color: var(--av); margin-bottom: .85rem; padding-bottom: .4rem; border-bottom: 1px solid var(--bd);
     }
-    .sb-row { display: flex; align-items: flex-start; gap: .55rem; margin-bottom: .5rem; }
-    .sb-ico { width: 13px; height: 13px; flex-shrink: 0; margin-top: 2px; opacity: .35; }
-    .sb-val { font-size: 10.5px; color: #888; line-height: 1.5; }
-    .sb-val a { color: #888; }
-    .sb-val a:hover { color: var(--accent); }
-    .skill-item  { margin-bottom: .7rem; }
-    .skill-top   { display: flex; justify-content: space-between; margin-bottom: .3rem; }
-    .skill-name  { font-size: 10.5px; color: #999; }
-    .skill-pct   { font-size: 9.5px; color: var(--muted); }
-    .skill-track { height: 2px; background: #1f1f1f; border-radius: 1px; }
-    .skill-bar   { height: 100%; background: var(--accent); border-radius: 1px; opacity: .7; }
-    .lang-row  { display: flex; justify-content: space-between; align-items: center; margin-bottom: .45rem; }
-    .lang-name { font-size: 10.5px; color: #888; }
-    .lang-dots { display: flex; gap: 4px; }
-    .lang-dot  { width: 6px; height: 6px; border-radius: 50%; background: #1f1f1f; }
-    .lang-dot.on { background: var(--accent); }
-    .social-row { display: flex; gap: 5px; flex-wrap: wrap; }
+    .sb-row { display: flex; align-items: flex-start; gap: .6rem; margin-bottom: .55rem; }
+    .sb-ico { width: 13px; height: 13px; flex-shrink: 0; margin-top: 2px; opacity: .4; }
+    .sb-val { font-size: 11px; color: var(--muted); line-height: 1.5; }
+    .sb-val a { color: var(--muted); transition: color .2s; }
+    .sb-val a:hover { color: var(--ac); }
+    .skill-item { margin-bottom: .85rem; }
+    .skill-top { display: flex; justify-content: space-between; margin-bottom: .35rem; }
+    .skill-name { font-size: 11px; color: var(--muted); }
+    .skill-pct { font-family: var(--fm); font-size: 9px; color: var(--ac); }
+    .skill-track { height: 3px; background: var(--bd); border-radius: 2px; }
+    .skill-bar { height: 100%; background: linear-gradient(90deg, var(--ac) 0%, var(--av) 100%); border-radius: 2px; }
+    .lang-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: .5rem; }
+    .lang-name { font-size: 11px; color: var(--muted); }
+    .lang-dots { display: flex; gap: 5px; }
+    .lang-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--bd); }
+    .lang-dot.on { background: var(--av); box-shadow: 0 0 5px rgba(124,92,252,.5); }
+    .social-row { display: flex; gap: 6px; flex-wrap: wrap; }
     .social-btn {
-      font-family: var(--font-h); font-size: 8px; letter-spacing: .1em; text-transform: uppercase;
-      padding: .28rem .6rem; border: 1px solid var(--border); color: var(--muted);
-      border-radius: 2px; transition: border-color .2s, color .2s;
+      font-family: var(--fm); font-size: 8px; letter-spacing: .1em; text-transform: uppercase;
+      padding: .3rem .65rem; border: 1px solid var(--bd-ui); color: var(--dim);
+      border-radius: 999px; transition: border-color .2s, color .2s;
     }
-    .social-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .social-btn:hover { border-color: var(--av); color: var(--av); }
 
-    /* ── Main ── */
+    /* ── Main area ── */
     .main { flex: 1; display: flex; flex-direction: column; min-width: 0; height: 100vh; overflow: hidden; }
     .top-nav {
       display: flex; align-items: stretch;
-      border-bottom: 1px solid var(--border); background: #0f0f0f;
+      border-bottom: 1px solid var(--bd);
+      background: rgba(11,11,15,.88);
+      backdrop-filter: blur(10px);
       flex-shrink: 0; height: var(--nav-h);
       overflow-x: auto; overflow-y: hidden;
     }
     .top-nav::-webkit-scrollbar { display: none; }
     .nav-item {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .16em; text-transform: uppercase;
-      color: var(--muted); padding: 0 1.1rem; cursor: pointer;
+      font-family: var(--fm); font-size: 9px; letter-spacing: .14em; text-transform: uppercase;
+      color: var(--dim); padding: 0 1.25rem; cursor: pointer;
       border-bottom: 2px solid transparent; white-space: nowrap; flex-shrink: 0;
       display: flex; align-items: center; transition: color .2s;
     }
-    .nav-item:hover  { color: var(--text); }
-    .nav-item.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .nav-item:hover { color: var(--muted); }
+    .nav-item.active { color: var(--av); border-bottom-color: var(--av); }
     .nav-spacer { flex: 1; min-width: 8px; }
     .lang-toggle {
       display: flex; align-items: center;
-      margin: 6px 10px 6px 0;
-      background: #1a1a1a; border: 1px solid var(--border); border-radius: 3px;
+      margin: 8px 12px 8px 0;
+      background: var(--bg-s); border: 1px solid var(--bd-ui); border-radius: 4px;
       overflow: hidden; flex-shrink: 0;
     }
     .lang-btn {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .12em;
-      padding: .25rem .55rem; cursor: pointer; color: var(--muted);
+      font-family: var(--fm); font-size: 9px; letter-spacing: .1em;
+      padding: .28rem .6rem; cursor: pointer; color: var(--dim);
       background: transparent; border: none; transition: background .15s, color .15s;
     }
-    .lang-btn.active { background: var(--accent); color: #111; }
-    .lang-div { width: 1px; height: 12px; background: var(--border); }
+    .lang-btn.active { background: var(--av); color: #fff; }
+    .lang-div { width: 1px; height: 12px; background: var(--bd-ui); }
     .pages { flex: 1; overflow-y: auto; overflow-x: hidden; }
-    .page  { display: none; }
+    .page { display: none; }
     .page.active { display: block; }
 
+    /* ── Fade-up animation ── */
+    .fade-up { opacity: 0; transform: translateY(14px); transition: opacity .55s ease, transform .55s ease; }
+    .fade-up.vis { opacity: 1; transform: none; }
+
     /* ── Home ── */
-    .home-hero { padding: 3rem 2.5rem 2rem; border-bottom: 1px solid var(--border); }
-    .hero-hi   { font-size: 9.5px; letter-spacing: .2em; text-transform: uppercase; color: var(--muted); margin-bottom: .6rem; }
-    .hero-name { font-family: var(--font-h); font-size: 40px; font-weight: 300; color: #f0f0f0; line-height: 1.05; margin-bottom: .5rem; }
-    .hero-name b { font-weight: 700; }
-    .hero-typed { font-family: var(--font-h); font-size: 14px; font-weight: 300; color: var(--muted); margin-bottom: 1rem; min-height: 20px; }
-    .tw-text   { color: var(--accent); font-weight: 500; }
-    .tw-cursor { color: var(--accent); animation: blink 1s step-end infinite; }
-    @keyframes blink { 0%,100%{opacity:1}50%{opacity:0} }
-    .hero-bio  { font-size: 12.5px; color: var(--muted); line-height: 1.75; max-width: 500px; margin-bottom: 1.75rem; }
-    .hero-btns { display: flex; gap: .65rem; flex-wrap: wrap; }
-    .hero-btn {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .16em; text-transform: uppercase;
-      padding: .55rem 1.35rem; border-radius: 2px; cursor: pointer;
-      transition: background .2s, color .2s, border-color .2s;
+    .home-hero {
+      padding: 4rem 3rem 3rem; border-bottom: 1px solid var(--bd);
+      position: relative; overflow: hidden;
     }
-    .hero-btn.primary   { background: var(--accent); color: #111; border: 1px solid var(--accent); }
-    .hero-btn.primary:hover { background: transparent; color: var(--accent); }
-    .hero-btn.secondary { background: transparent; color: var(--muted); border: 1px solid var(--border); }
-    .hero-btn.secondary:hover { border-color: var(--text); color: var(--text); }
-    .home-stats { display: grid; }
-    .stat { padding: 1.25rem 1.5rem; border-right: 1px solid var(--border); text-align: center; }
+    .home-hero::before {
+      content: '';
+      position: absolute; top: -140px; left: -140px;
+      width: 560px; height: 560px;
+      background: radial-gradient(circle, rgba(124,92,252,.1) 0%, transparent 65%);
+      pointer-events: none;
+    }
+    .hero-label {
+      font-family: var(--fm); font-size: 10px; letter-spacing: .2em; text-transform: lowercase;
+      color: var(--ac); margin-bottom: .9rem;
+    }
+    .hero-name {
+      font-size: 58px; line-height: 1.0; margin-bottom: .65rem;
+      display: flex; flex-wrap: wrap; align-items: baseline; gap: .2em;
+    }
+    .hero-first { font-family: var(--fb); font-weight: 300; color: var(--text); letter-spacing: -.01em; }
+    .hero-last {
+      font-family: var(--fd); font-style: italic; color: var(--av);
+      text-shadow: 0 0 36px rgba(124,92,252,.45); letter-spacing: -.01em;
+    }
+    .hero-typed { font-family: var(--fb); font-size: 15px; font-weight: 300; color: var(--muted); margin-bottom: 1.5rem; min-height: 22px; }
+    .tw-text { color: var(--ap); font-weight: 500; }
+    .tw-cursor { color: var(--av); animation: blink 1s step-end infinite; }
+    @keyframes blink { 0%,100%{opacity:1}50%{opacity:0} }
+    .hero-bio { font-size: 13.5px; color: var(--muted); line-height: 1.8; max-width: 520px; margin-bottom: 2rem; }
+    .hero-btns { display: flex; gap: .75rem; flex-wrap: wrap; }
+    .hero-btn {
+      font-family: var(--fm); font-size: 9px; letter-spacing: .14em; text-transform: uppercase;
+      padding: .65rem 1.5rem; border-radius: 4px; cursor: pointer; transition: opacity .2s, box-shadow .2s;
+    }
+    .hero-btn.primary {
+      background: linear-gradient(135deg, var(--av) 0%, var(--ap) 100%);
+      color: #fff; border: none; box-shadow: 0 2px 18px rgba(124,92,252,.28);
+    }
+    .hero-btn.primary:hover { opacity: .85; box-shadow: 0 4px 28px rgba(124,92,252,.45); }
+    .hero-btn.secondary { background: transparent; color: var(--muted); border: 1px solid var(--bd-ui); }
+    .hero-btn.secondary:hover { border-color: var(--muted); color: var(--text); }
+    .home-stats { display: grid; border-top: 1px solid var(--bd); }
+    .stat { padding: 1.5rem 2rem; border-right: 1px solid var(--bd); text-align: center; }
     .stat:last-child { border-right: none; }
-    .stat-n { font-family: var(--font-h); font-size: 26px; font-weight: 700; color: var(--accent); }
-    .stat-l { font-size: 8.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-top: .25rem; }
+    .stat-n {
+      font-family: var(--fm); font-size: 28px; font-weight: 500; color: var(--ac);
+      text-shadow: 0 0 18px rgba(74,227,209,.28); margin-bottom: .3rem;
+    }
+    .stat-l { font-family: var(--fm); font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: var(--dim); }
 
     /* ── Resume ── */
-    .resume-page { padding: 1.75rem 2.25rem; }
-    .res-section { margin-bottom: 2rem; }
+    .resume-page { padding: 2.5rem 3rem; }
+    .res-section { margin-bottom: 2.5rem; }
     .res-head {
-      font-family: var(--font-h); font-size: 9.5px; letter-spacing: .2em; text-transform: uppercase;
-      color: var(--accent); margin-bottom: 1.25rem;
-      display: flex; align-items: center; gap: .65rem;
+      font-family: var(--fm); font-size: 9px; letter-spacing: .2em; text-transform: uppercase;
+      color: var(--av); margin-bottom: 1.5rem; display: flex; align-items: center; gap: .65rem;
     }
-    .res-head::after { content: ''; flex: 1; height: 1px; background: var(--border); }
-    .tl-item { display: flex; gap: 1.1rem; margin-bottom: 1.25rem; }
-    .tl-left { display: flex; flex-direction: column; align-items: center; width: 10px; flex-shrink: 0; }
-    .tl-dot  { width: 7px; height: 7px; border-radius: 50%; border: 1px solid var(--accent); flex-shrink: 0; margin-top: 4px; }
-    .tl-line { width: 1px; background: var(--border); flex: 1; margin-top: 4px; }
-    .tl-body { flex: 1; padding-bottom: .4rem; }
-    .tl-aar    { font-size: 9.5px; letter-spacing: .06em; color: var(--muted); margin-bottom: .2rem; }
-    .tl-tittel { font-family: var(--font-h); font-size: 12.5px; font-weight: 600; color: #e0e0e0; margin-bottom: .12rem; }
-    .tl-sted   { font-size: 10.5px; color: var(--accent); margin-bottom: .3rem; }
-    .tl-tekst  { font-size: 10.5px; color: var(--muted); line-height: 1.6; }
+    .res-head::before { content: '//'; color: var(--av); opacity: .45; margin-right: -.1rem; }
+    .res-head::after { content: ''; flex: 1; height: 1px; background: var(--bd); }
+    .tl-item { display: flex; gap: 1.25rem; margin-bottom: 1.5rem; }
+    .tl-left { display: flex; flex-direction: column; align-items: center; width: 12px; flex-shrink: 0; }
+    .tl-dot { width: 9px; height: 9px; border-radius: 50%; border: 1.5px solid var(--av); flex-shrink: 0; margin-top: 3px; background: transparent; }
+    .tl-item:first-child .tl-dot { background: var(--av); box-shadow: 0 0 8px rgba(124,92,252,.55); }
+    .tl-line { width: 1px; background: var(--bd); flex: 1; margin-top: 4px; }
+    .tl-body { flex: 1; padding-bottom: .5rem; }
+    .tl-aar { font-family: var(--fm); font-size: 9.5px; letter-spacing: .05em; color: var(--dim); margin-bottom: .3rem; }
+    .tl-tittel { font-family: var(--fb); font-size: 13px; font-weight: 600; color: var(--text); margin-bottom: .15rem; }
+    .tl-sted { font-size: 11px; color: var(--av); margin-bottom: .35rem; opacity: .8; }
+    .tl-tekst { font-size: 11.5px; color: var(--muted); line-height: 1.65; }
 
     /* ── Works ── */
-    .works-page   { padding: 1.5rem 1.75rem; }
-    .works-filter { display: flex; gap: .45rem; margin-bottom: 1.25rem; flex-wrap: wrap; }
+    .works-page { padding: 2rem 2.5rem; }
+    .works-filter { display: flex; gap: .5rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
     .wf-btn {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .12em; text-transform: uppercase;
-      padding: .3rem .8rem; border: 1px solid var(--border); color: var(--muted);
-      border-radius: 2px; cursor: pointer; transition: border-color .2s, color .2s;
+      font-family: var(--fm); font-size: 9px; letter-spacing: .1em; text-transform: lowercase;
+      padding: .35rem .9rem; border: 1px solid var(--bd-ui); color: var(--dim);
+      border-radius: 999px; cursor: pointer; transition: border-color .2s, color .2s, background .2s;
     }
-    .wf-btn:hover  { border-color: #333; color: var(--text); }
-    .wf-btn.active { border-color: var(--accent); color: var(--accent); }
-    .works-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 10px; }
+    .wf-btn:hover { border-color: var(--muted); color: var(--muted); }
+    .wf-btn.active { border-color: var(--av); color: var(--av); background: var(--ag); }
+    .works-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; }
     .work-card {
-      background: var(--card); border: 1px solid var(--border);
-      border-radius: 4px; overflow: hidden; cursor: pointer;
-      transition: border-color .2s, transform .2s;
+      background: var(--bg-r); border: 1px solid var(--bd);
+      border-radius: 12px; overflow: hidden; cursor: pointer;
+      transition: border-color .25s, box-shadow .25s, transform .25s;
     }
-    .work-card:hover { border-color: #333; transform: translateY(-1px); }
-    .work-card.no-video { cursor: default; }
-    .work-card.no-video:hover { transform: none; }
-    .work-thumb { aspect-ratio: 16/9; background: #161616; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; }
-    .work-thumb img { width: 100%; height: 100%; object-fit: cover; filter: brightness(.6); transition: filter .3s; }
-    .work-card:hover .work-thumb img { filter: brightness(.4); }
-    .play-ico {
-      position: absolute; width: 38px; height: 38px; border-radius: 50%;
-      border: 1px solid rgba(255,255,255,.25);
+    .work-card:hover {
+      border-color: rgba(124,92,252,.5);
+      box-shadow: 0 0 0 1px var(--ag), 0 8px 32px rgba(0,0,0,.5);
+      transform: translateY(-2px);
+    }
+    .work-card.no-click { cursor: default; }
+    .work-card.no-click:hover { transform: none; border-color: var(--bd); box-shadow: none; }
+    .work-thumb {
+      aspect-ratio: 16/9; background: var(--bg-s);
       display: flex; align-items: center; justify-content: center;
-      transition: border-color .2s, transform .2s;
+      position: relative; overflow: hidden;
     }
-    .work-card:hover .play-ico { border-color: var(--accent); transform: scale(1.1); }
-    .work-info  { padding: .55rem .75rem; }
-    .work-title { font-family: var(--font-h); font-size: 10.5px; font-weight: 600; color: #ccc; }
-    .work-role  { font-size: 8.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--muted); margin-top: .18rem; }
-    /* FIX: tekst under rolle på prosjektkort */
-    .work-tekst { font-size: 9.5px; color: var(--muted); line-height: 1.5; margin-top: .3rem; opacity: .8; }
-    .work-badge { display: inline-block; font-size: 7.5px; letter-spacing: .08em; text-transform: uppercase; padding: 2px 5px; border-radius: 2px; margin-top: .25rem; background: rgba(200,169,110,.1); color: var(--accent); }
+    .work-thumb img { width: 100%; height: 100%; object-fit: cover; filter: brightness(.65); transition: filter .3s; }
+    .work-card:hover .work-thumb img { filter: brightness(.4); }
+    .thumb-grad {
+      width: 100%; height: 100%;
+      background: linear-gradient(135deg, rgba(124,92,252,.25) 0%, rgba(212,79,168,.18) 100%);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .thumb-grad-tech { background: linear-gradient(135deg, rgba(74,227,209,.12) 0%, rgba(124,92,252,.18) 100%); }
+    .play-ico {
+      position: absolute; width: 42px; height: 42px; border-radius: 50%;
+      border: 1.5px solid rgba(255,255,255,.28);
+      display: flex; align-items: center; justify-content: center;
+      transition: border-color .2s, transform .2s, background .2s;
+    }
+    .work-card:hover .play-ico { border-color: var(--av); background: var(--ag); transform: scale(1.1); }
+    .work-info { padding: .75rem 1rem; }
+    .work-title { font-family: var(--fb); font-size: 12px; font-weight: 600; color: var(--text); margin-bottom: .2rem; }
+    .work-role { font-family: var(--fm); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; color: var(--dim); }
+    .work-tekst { font-size: 10.5px; color: var(--muted); line-height: 1.5; margin-top: .3rem; }
+    .work-badge {
+      display: inline-block; font-family: var(--fm); font-size: 8px; letter-spacing: .06em;
+      padding: 2px 8px; border-radius: 4px; margin-top: .4rem;
+      background: rgba(74,227,209,.07); color: var(--ac); border: 1px solid rgba(74,227,209,.2);
+    }
+    .work-link-row { display: flex; gap: .4rem; margin-top: .5rem; flex-wrap: wrap; }
+    .work-link {
+      font-family: var(--fm); font-size: 8px; letter-spacing: .07em; text-transform: uppercase;
+      padding: 2px 8px; border-radius: 4px; border: 1px solid var(--bd-ui); color: var(--dim);
+      transition: border-color .2s, color .2s; display: inline-block;
+    }
+    .work-link:hover { border-color: var(--av); color: var(--av); }
 
     /* ── Lightbox ── */
     .lb { display: none; position: fixed; inset: 0; z-index: 1000; align-items: center; justify-content: center; }
     .lb.open { display: flex; }
-    .lb-bd { position: absolute; inset: 0; background: rgba(0,0,0,.9); cursor: pointer; }
+    .lb-bd { position: absolute; inset: 0; background: rgba(0,0,0,.92); cursor: pointer; }
     .lb-box { position: relative; width: min(92vw,1000px); aspect-ratio: 16/9; z-index: 1; }
-    .lb-box iframe { width: 100%; height: 100%; border: 0; }
+    .lb-box iframe { width: 100%; height: 100%; border: 0; border-radius: 8px; }
     .lb-close {
-      position: absolute; top: -40px; right: 0;
-      background: none; border: none; color: #fff;
-      font-family: var(--font-h); font-size: 10px; letter-spacing: .1em;
-      cursor: pointer; opacity: .6; transition: opacity .2s;
+      position: absolute; top: -42px; right: 0;
+      background: none; border: none; color: var(--muted);
+      font-family: var(--fm); font-size: 9px; letter-spacing: .12em;
+      cursor: pointer; opacity: .7; transition: opacity .2s, color .2s;
     }
-    .lb-close:hover { opacity: 1; }
+    .lb-close:hover { opacity: 1; color: var(--text); }
 
     /* ── Contact ── */
-    .contact-page  { padding: 1.75rem 2.25rem; }
-    .contact-cards { display: grid; grid-template-columns: repeat(2,1fr); gap: 10px; margin-bottom: 1.75rem; }
-    .cc { background: var(--card); border: 1px solid var(--border); border-radius: 4px; padding: 1rem; text-align: center; }
-    .cc-ico   { width: 32px; height: 32px; background: #1a1a1a; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin: 0 auto .6rem; }
-    .cc-label { font-size: 8.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); margin-bottom: .25rem; }
-    .cc-val   { font-size: 10.5px; color: #888; }
-    .cc-val a { color: #888; transition: color .2s; }
-    .cc-val a:hover { color: var(--accent); }
-    .form-sec-title {
-      font-family: var(--font-h); font-size: 9.5px; letter-spacing: .18em; text-transform: uppercase;
-      color: var(--accent); margin-bottom: 1rem;
-      display: flex; align-items: center; gap: .65rem;
+    .contact-page { padding: 2.5rem 3rem; }
+    .contact-headline { font-family: var(--fd); font-style: italic; font-size: 38px; color: var(--text); margin-bottom: .35rem; line-height: 1.1; }
+    .contact-sub { font-family: var(--fm); font-size: 9.5px; letter-spacing: .14em; color: var(--dim); text-transform: uppercase; margin-bottom: 2rem; }
+    .contact-cards { display: grid; grid-template-columns: repeat(2,1fr); gap: 10px; margin-bottom: 2rem; }
+    .cc { background: var(--bg-r); border: 1px solid var(--bd); border-radius: 12px; padding: 1.1rem; display: flex; align-items: center; gap: .85rem; }
+    .cc-ico { width: 36px; height: 36px; border-radius: 8px; background: var(--bg-s); border: 1px solid var(--bd-ui); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .cc-label { font-family: var(--fm); font-size: 8.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--dim); margin-bottom: .18rem; }
+    .cc-val { font-size: 11px; color: var(--muted); }
+    .cc-val a { color: var(--muted); transition: color .2s; }
+    .cc-val a:hover { color: var(--ac); }
+    .form-sec-head {
+      font-family: var(--fm); font-size: 9px; letter-spacing: .18em; text-transform: uppercase;
+      color: var(--av); margin-bottom: 1rem; display: flex; align-items: center; gap: .65rem;
     }
-    .form-sec-title::after { content: ''; flex: 1; height: 1px; background: var(--border); }
-    .form-row  { display: flex; gap: 8px; margin-bottom: 8px; }
+    .form-sec-head::before { content: '//'; opacity: .45; }
+    .form-sec-head::after { content: ''; flex: 1; height: 1px; background: var(--bd); }
+    .form-row { display: flex; gap: 8px; margin-bottom: 8px; }
     .form-in {
-      flex: 1; background: #161616; border: 1px solid var(--border);
-      color: var(--text); padding: .58rem .8rem; border-radius: 2px;
-      font-size: 10.5px; font-family: var(--font-b); outline: none; transition: border-color .2s;
+      flex: 1; background: var(--bg-r); border: 1px solid var(--bd-ui);
+      color: var(--text); padding: .65rem .9rem; border-radius: 8px;
+      font-size: 12px; font-family: var(--fb); outline: none;
+      transition: border-color .2s, box-shadow .2s;
     }
-    .form-in:focus { border-color: #333; }
-    textarea.form-in { resize: none; height: 85px; width: 100%; margin-bottom: 8px; }
+    .form-in::placeholder { color: var(--dim); }
+    .form-in:focus { border-color: var(--av); box-shadow: 0 0 0 3px var(--ag); }
+    textarea.form-in { resize: none; height: 100px; width: 100%; margin-bottom: 8px; }
     .form-submit {
-      font-family: var(--font-h); font-size: 8.5px; letter-spacing: .16em; text-transform: uppercase;
-      padding: .55rem 1.5rem; background: var(--accent); color: #111; border: 1px solid var(--accent);
-      border-radius: 2px; cursor: pointer; transition: background .2s, color .2s;
+      font-family: var(--fm); font-size: 9px; letter-spacing: .14em; text-transform: uppercase;
+      padding: .65rem 1.75rem;
+      background: linear-gradient(135deg, var(--av) 0%, var(--ap) 100%);
+      color: #fff; border: none; border-radius: 8px; cursor: pointer;
+      box-shadow: 0 2px 16px rgba(124,92,252,.22);
+      transition: opacity .2s, box-shadow .2s;
     }
-    .form-submit:hover { background: transparent; color: var(--accent); }
-    .form-submit:disabled { opacity: .5; cursor: not-allowed; }
-    .form-msg {
-      margin-top: .75rem; font-size: 11px; padding: .5rem .75rem;
-      border-radius: 2px; display: none;
-    }
-    .form-msg.ok  { display: block; background: rgba(100,200,100,.1); color: #7ec87e; border: 1px solid rgba(100,200,100,.2); }
-    .form-msg.err { display: block; background: rgba(200,80,80,.1);  color: #e07878; border: 1px solid rgba(200,80,80,.2); }
-    .form-no-setup { font-size: 11px; color: var(--muted); font-style: italic; margin-top: .5rem; }
+    .form-submit:hover { opacity: .85; box-shadow: 0 4px 24px rgba(124,92,252,.4); }
+    .form-submit:disabled { opacity: .4; cursor: not-allowed; }
+    .form-msg { margin-top: .75rem; font-size: 11.5px; padding: .6rem .85rem; border-radius: 8px; display: none; }
+    .form-msg.ok  { display: block; background: rgba(74,227,209,.07); color: var(--ac); border: 1px solid rgba(74,227,209,.2); }
+    .form-msg.err { display: block; background: rgba(200,80,80,.07); color: #e07878; border: 1px solid rgba(200,80,80,.2); }
 
     /* ── Mobile nav ── */
-    .mob-nav { display: none; position: fixed; bottom: 0; left: 0; right: 0; background: #0a0a0a; border-top: 1px solid var(--border); z-index: 200; height: 56px; }
+    .mob-nav {
+      display: none; position: fixed; bottom: 0; left: 0; right: 0;
+      background: rgba(11,11,15,.94); backdrop-filter: blur(12px);
+      border-top: 1px solid var(--bd); z-index: 200; height: 58px;
+    }
     .mob-nav-inner { display: flex; height: 100%; }
     .mob-nav-item {
       flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
-      gap: 3px; cursor: pointer; color: var(--muted);
-      font-family: var(--font-h); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; transition: color .2s;
+      gap: 3px; cursor: pointer; color: var(--dim);
+      font-family: var(--fm); font-size: 8px; letter-spacing: .1em; text-transform: uppercase;
+      transition: color .2s;
     }
-    .mob-nav-item.active { color: var(--accent); }
+    .mob-nav-item.active { color: var(--av); }
     .mob-nav-item svg { width: 18px; height: 18px; }
 
+    /* ── Scrollbar ── */
+    ::-webkit-scrollbar { width: 4px; height: 4px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--bd-ui); border-radius: 2px; }
+    ::-webkit-scrollbar-thumb:hover { background: var(--av); }
+
     /* ── Responsive ── */
-    @media (max-width: 900px) { :root { --sb: 220px; } }
+    @media (max-width: 1100px) { .works-grid { grid-template-columns: repeat(2,1fr); } }
+    @media (max-width: 900px)  { :root { --sb: 240px; } }
 
     @media (max-width: 680px) {
       body { overflow: auto; }
@@ -551,42 +676,32 @@
       .main { height: auto; overflow: visible; }
       .top-nav { display: none; }
       .mob-nav { display: block; }
-      .pages { overflow: visible; padding-bottom: 64px; }
-      .home-hero { padding: 2rem 1.25rem 1.5rem; }
-      .hero-name { font-size: 32px; }
-      .hero-bio  { font-size: 12px; }
-      .home-stats .stat { padding: 1rem .75rem; }
-      .stat-n { font-size: 22px; }
-      .stat-l { font-size: 8px; }
-      .resume-page  { padding: 1.25rem; }
-      .works-page   { padding: 1.25rem; }
-      .contact-page { padding: 1.25rem; }
-      .works-grid { grid-template-columns: 1fr 1fr; gap: 8px; }
-      .contact-cards { grid-template-columns: 1fr 1fr; gap: 8px; }
-      .tl-tittel { font-size: 12px; }
-      .tl-sted   { font-size: 10px; }
-      .tl-tekst  { font-size: 10px; }
+      .pages { overflow: visible; padding-bottom: 66px; }
+      .home-hero { padding: 2.5rem 1.5rem 2rem; }
+      .hero-name { font-size: 44px; }
+      .home-stats .stat { padding: 1.25rem 1rem; }
+      .stat-n { font-size: 24px; }
+      .resume-page  { padding: 1.75rem 1.5rem; }
+      .works-page   { padding: 1.5rem; }
+      .works-grid   { grid-template-columns: repeat(2,1fr); gap: 10px; }
+      .contact-page { padding: 1.75rem 1.5rem; }
+      .contact-cards { grid-template-columns: 1fr 1fr; }
+      .tl-tittel { font-size: 12.5px; }
     }
     @media (max-width: 420px) {
       .works-grid    { grid-template-columns: 1fr; }
       .contact-cards { grid-template-columns: 1fr; }
-      .hero-name     { font-size: 28px; }
+      .hero-name     { font-size: 36px; }
+      .contact-headline { font-size: 28px; }
     }
     @media (max-width: 680px) and (orientation: landscape) {
       .mob-nav { display: none; }
       .top-nav { display: flex; }
       .pages { padding-bottom: 0; }
-      .home-hero { padding: 1.5rem 1.5rem 1.25rem; }
-      .hero-name { font-size: 28px; }
-      .hero-bio  { display: none; }
-      .home-stats .stat { padding: .85rem 1rem; }
-      .stat-n { font-size: 20px; }
+      .home-hero { padding: 1.5rem; }
+      .hero-name { font-size: 34px; }
+      .hero-bio { display: none; }
     }
-
-    ::-webkit-scrollbar { width: 4px; height: 4px; }
-    ::-webkit-scrollbar-track { background: transparent; }
-    ::-webkit-scrollbar-thumb { background: #2a2a2a; border-radius: 2px; }
-    ::-webkit-scrollbar-thumb:hover { background: #333; }
   </style>
 </head>
 <body>
@@ -628,9 +743,10 @@
 
       <div class="pages">
 
+        <!-- HOME -->
         <div class="page active" id="page-home">
           <div class="home-hero">
-            <div class="hero-hi" id="heroHi"></div>
+            <div class="hero-label" id="heroLabel"></div>
             <div class="hero-name" id="heroNavn"></div>
             <div class="hero-typed">
               <span id="jegLager"></span>&nbsp;<span class="tw-text" id="twText"></span><span class="tw-cursor">|</span>
@@ -644,6 +760,7 @@
           <div class="home-stats" id="homeStats"></div>
         </div>
 
+        <!-- RESUME -->
         <div class="page" id="page-resume">
           <div class="resume-page">
             <div class="res-section"><div class="res-head" id="resErfaring"></div><div id="erfaringListe"></div></div>
@@ -652,6 +769,7 @@
           </div>
         </div>
 
+        <!-- WORKS -->
         <div class="page" id="page-works">
           <div class="works-page">
             <div class="works-filter" id="worksFilter"></div>
@@ -659,16 +777,19 @@
           </div>
         </div>
 
+        <!-- CONTACT -->
         <div class="page" id="page-contact">
           <div class="contact-page">
-            <div class="contact-cards" id="contactCards"></div>
-            <div class="form-sec-title" id="formTittel"></div>
+            <div class="contact-headline" id="contactHeadline"></div>
+            <div class="contact-sub"      id="contactSub"></div>
+            <div class="contact-cards"    id="contactCards"></div>
+            <div class="form-sec-head"    id="formTittel"></div>
             <div id="formWrap">
               <div class="form-row">
                 <input class="form-in" id="fNavn"  type="text" />
                 <input class="form-in" id="fEpost" type="email" />
               </div>
-              <input    class="form-in" id="fEmne"    type="text" style="width:100%;margin-bottom:8px;" />
+              <input    class="form-in" id="fEmne"    type="text"  style="width:100%;margin-bottom:8px;" />
               <textarea class="form-in" id="fMelding"></textarea>
               <button   class="form-submit" id="fSend"></button>
               <div class="form-msg" id="formMsg"></div>
@@ -692,30 +813,32 @@
     function htm(id, h)   { const e=$(id); if(e) e.innerHTML=h; }
     function initials(n)  { return n.split(' ').map(w=>w[0]).slice(0,2).join('').toUpperCase(); }
 
-    document.documentElement.style.setProperty('--accent', CV.aksent||'#c8a96e');
+    document.documentElement.style.setProperty('--av', CV.aksent || '#7c5cfc');
 
     // Avatar
-    const avEl=$('sbAvatar');
+    const avEl = $('sbAvatar');
     if (CV.bilde) {
-      const img=mk('img'); img.src=CV.bilde; img.alt=CV.navn;
-      img.onerror=()=>{ img.remove(); avEl.textContent=initials(CV.navn); };
+      const img = mk('img'); img.src = CV.bilde; img.alt = CV.navn;
+      img.onerror = () => { img.remove(); avEl.textContent = initials(CV.navn); };
       avEl.appendChild(img);
-    } else { avEl.textContent=initials(CV.navn); }
+    } else { avEl.textContent = initials(CV.navn); }
 
     set('sbNavn', CV.navn);
-    if (CV.cvPdf) $('sbCvLink').href=CV.cvPdf;
-    else $('sbCvLink').style.display='none';
+    if (CV.cvPdf) $('sbCvLink').href = CV.cvPdf;
+    else $('sbCvLink').style.display = 'none';
 
     // Sosiale
-    const aktSos=(CV.sosiale||[]).filter(s=>s.url);
+    const aktSos = (CV.sosiale || []).filter(s => s.url);
     if (aktSos.length) {
-      aktSos.forEach(s=>{ $('sbSosiale').insertAdjacentHTML('beforeend',
-        `<a class="social-btn" href="${s.url}" target="_blank" rel="noopener">${s.label}</a>`); });
-    } else { $('sbSosialeSek').style.display='none'; }
+      aktSos.forEach(s => {
+        $('sbSosiale').insertAdjacentHTML('beforeend',
+          `<a class="social-btn" href="${s.url}" target="_blank" rel="noopener">${s.label}</a>`);
+      });
+    } else { $('sbSosialeSek').style.display = 'none'; }
 
     // Skill bars
-    (CV.ferdigheter||[]).forEach(f=>{
-      $('sbFerdigheter').insertAdjacentHTML('beforeend',`
+    (CV.ferdigheter || []).forEach(f => {
+      $('sbFerdigheter').insertAdjacentHTML('beforeend', `
         <div class="skill-item">
           <div class="skill-top"><span class="skill-name" data-sk></span><span class="skill-pct">${f.prosent}%</span></div>
           <div class="skill-track"><div class="skill-bar" style="width:${f.prosent}%"></div></div>
@@ -723,191 +846,237 @@
     });
 
     // Lang dots
-    (CV.sprak||[]).forEach(s=>{
-      let dots='';
-      for(let i=1;i<=5;i++) dots+=`<div class="lang-dot${i<=s.nivaa?' on':''}"></div>`;
-      $('sbSprak').insertAdjacentHTML('beforeend',`
+    (CV.sprak || []).forEach(s => {
+      let dots = '';
+      for (let i = 1; i <= 5; i++) dots += `<div class="lang-dot${i <= s.nivaa ? ' on' : ''}"></div>`;
+      $('sbSprak').insertAdjacentHTML('beforeend', `
         <div class="lang-row"><span class="lang-name" data-ln></span><div class="lang-dots">${dots}</div></div>`);
     });
 
     // Stats
-    const sEl=$('homeStats');
-    sEl.style.gridTemplateColumns=`repeat(${CV.stats.length},1fr)`;
-    CV.stats.forEach((s,i)=>{
-      const d=mk('div'); d.className='stat';
-      if(i===CV.stats.length-1) d.style.borderRight='none';
-      d.innerHTML=`<div class="stat-n">${s.tall}</div><div class="stat-l" data-stl></div>`;
+    const sEl = $('homeStats');
+    sEl.style.gridTemplateColumns = `repeat(${CV.stats.length},1fr)`;
+    CV.stats.forEach((s, i) => {
+      const d = mk('div'); d.className = 'stat fade-up';
+      d.style.transitionDelay = `${i * 80}ms`;
+      if (i === CV.stats.length - 1) d.style.borderRight = 'none';
+      d.innerHTML = `<div class="stat-n">${s.tall}</div><div class="stat-l" data-stl></div>`;
       sEl.appendChild(d);
     });
 
-    // Prosjekt-kort
-    const kortRefs=[];
-    const alleKat=['alle',...new Set((CV.prosjekter||[]).map(p=>p.filter))];
-    alleKat.forEach(f=>{
-      const btn=mk('div'); btn.className='wf-btn'+(f==='alle'?' active':''); btn.dataset.fv=f;
-      btn.addEventListener('click',()=>{
-        document.querySelectorAll('.wf-btn').forEach(b=>b.classList.remove('active'));
+    // Intersection observer for fade-up animations
+    const io = new IntersectionObserver(entries => {
+      entries.forEach(e => { if (e.isIntersecting) e.target.classList.add('vis'); });
+    }, { threshold: 0.08, rootMargin: '0px 0px -24px 0px' });
+
+    // Project cards
+    const kortRefs = [];
+    const alleKat = ['alle', ...new Set((CV.prosjekter || []).map(p => p.filter))];
+    alleKat.forEach(f => {
+      const btn = mk('div');
+      btn.className = 'wf-btn' + (f === 'alle' ? ' active' : '');
+      btn.dataset.fv = f;
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.wf-btn').forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
-        document.querySelectorAll('.work-card').forEach(c=>{
-          c.style.display=(f==='alle'||c.dataset.filter===f)?'':'none';
+        document.querySelectorAll('.work-card').forEach(c => {
+          c.style.display = (f === 'alle' || c.dataset.filter === f) ? '' : 'none';
         });
       });
       $('worksFilter').appendChild(btn);
     });
-    (CV.prosjekter||[]).forEach(p=>{
-      const hv=p.type==='youtube'||p.type==='drive';
-      const card=mk('div');
-      card.className='work-card'+(hv?'':' no-video');
-      card.dataset.filter=p.filter;
-      let th='';
-      if(p.type==='youtube') th=`<img src="https://img.youtube.com/vi/${p.embed}/mqdefault.jpg" alt="${p.tittel}"/><div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#ccc"/></svg></div>`;
-      else if(hv)            th=`<div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#ccc"/></svg></div>`;
-      if(p.thumbnail)        th=`<img src="${p.thumbnail}" alt="${p.tittel}"/>`+(hv?`<div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#ccc"/></svg></div>`:'');
-      // FIX: vis tekst-felt under rolle hvis det finnes
-      card.innerHTML=`<div class="work-thumb">${th}</div>
+
+    (CV.prosjekter || []).forEach(p => {
+      const hasVideo = p.type === 'youtube' || p.type === 'drive';
+      const hasLink  = !hasVideo && !!p.lenke;
+      const card = mk('div');
+      card.className = 'work-card' + (!hasVideo && !hasLink ? ' no-click' : '');
+      card.dataset.filter = p.filter;
+
+      let th = '';
+      if (p.type === 'youtube') {
+        th = `<img src="https://img.youtube.com/vi/${p.embed}/mqdefault.jpg" alt="${p.tittel}"/>
+              <div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#fff"/></svg></div>`;
+      } else if (p.type === 'drive') {
+        th = `<div class="thumb-grad" style="width:100%;height:100%">
+                <div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#fff"/></svg></div>
+              </div>`;
+      } else {
+        th = `<div class="thumb-grad thumb-grad-tech" style="width:100%;height:100%">
+                <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="rgba(74,227,209,.45)" stroke-width="1.5">
+                  <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+                </svg>
+              </div>`;
+      }
+      if (p.thumbnail) {
+        th = `<img src="${p.thumbnail}" alt="${p.tittel}"/>` +
+             (hasVideo ? `<div class="play-ico"><svg viewBox="0 0 12 12" fill="none" width="12" height="12"><polygon points="3,1 11,6 3,11" fill="#fff"/></svg></div>` : '');
+      }
+
+      const linksHtml = (p.lenke || p.github)
+        ? `<div class="work-link-row">
+            ${p.lenke  ? `<a class="work-link" href="${p.lenke}"  target="_blank" rel="noopener">Live ↗</a>` : ''}
+            ${p.github ? `<a class="work-link" href="${p.github}" target="_blank" rel="noopener">GitHub ↗</a>` : ''}
+           </div>`
+        : '';
+
+      card.innerHTML = `<div class="work-thumb">${th}</div>
         <div class="work-info">
           <div class="work-title">${p.tittel}</div>
           <div class="work-role" data-wr></div>
-          ${p.tekst?'<div class="work-tekst" data-wtekst></div>':''}
-          ${!hv?'<div class="work-badge" data-wb></div>':''}
+          ${p.tekst  ? '<div class="work-tekst" data-wtekst></div>' : ''}
+          ${p.badge  ? '<div class="work-badge" data-wb></div>'     : ''}
+          ${linksHtml}
         </div>`;
-      if(hv) card.addEventListener('click',()=>openLb(p));
+
+      if (hasVideo) card.addEventListener('click', () => openLb(p));
+      if (hasLink)  card.addEventListener('click', e => {
+        if (!e.target.closest('.work-link')) window.open(p.lenke, '_blank', 'noopener');
+      });
       $('worksGrid').appendChild(card);
-      kortRefs.push({el:card,data:p});
+      kortRefs.push({ el: card, data: p });
     });
 
-    // Kontakt-kort
-    const ccSvg={
-      epost:'<rect x="1" y="3" width="14" height="10" rx="1" stroke="#888" stroke-width="1.2"/><path d="M1 4l7 5 7-5" stroke="#888" stroke-width="1.2"/>',
-      telefon:'<rect x="3" y="1" width="10" height="14" rx="2" stroke="#888" stroke-width="1.2"/><circle cx="8" cy="12" r="1" fill="#888"/>',
-      sted:'<path d="M8 1.5C5.5 1.5 3.5 3.5 3.5 6c0 3.5 4.5 8.5 4.5 8.5S12.5 9.5 12.5 6c0-2.5-2-4.5-4.5-4.5z" stroke="#888" stroke-width="1.2"/><circle cx="8" cy="6" r="1.5" stroke="#888" stroke-width="1.2"/>',
-      nettside:'<circle cx="8" cy="8" r="6" stroke="#888" stroke-width="1.2"/><path d="M8 2c0 0-2 3-2 6s2 6 2 6M8 2c0 0 2 3 2 6s-2 6-2 6M2 8h12" stroke="#888" stroke-width="1.2"/>',
+    // Contact info cards
+    const ccSvg = {
+      epost:   '<rect x="1" y="3" width="14" height="10" rx="1" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/><path d="M1 4l7 5 7-5" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/>',
+      telefon: '<rect x="3" y="1" width="10" height="14" rx="2" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/><circle cx="8" cy="12" r="1" fill="rgba(136,136,168,.65)"/>',
+      sted:    '<path d="M8 1.5C5.5 1.5 3.5 3.5 3.5 6c0 3.5 4.5 8.5 4.5 8.5S12.5 9.5 12.5 6c0-2.5-2-4.5-4.5-4.5z" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/><circle cx="8" cy="6" r="1.5" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/>',
+      nettside:'<circle cx="8" cy="8" r="6" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/><path d="M8 2c0 0-2 3-2 6s2 6 2 6M8 2c0 0 2 3 2 6s-2 6-2 6M2 8h12" stroke="rgba(136,136,168,.65)" stroke-width="1.2"/>',
     };
-    [{key:'epost',val:CV.epost,href:'mailto:'+CV.epost},
-     {key:'telefon',val:CV.telefon,href:'tel:'+(CV.telefon||'').replace(/\s/g,'')},
-     {key:'sted',val:CV.sted,href:null},
-     {key:'nettside',val:CV.nettside,href:'https://'+CV.nettside},
-    ].forEach(k=>{
-      if(!k.val) return;
-      $('contactCards').insertAdjacentHTML('beforeend',`
+    [
+      { key: 'epost',    val: CV.epost,    href: 'mailto:' + CV.epost },
+      { key: 'telefon',  val: CV.telefon,  href: 'tel:' + (CV.telefon || '').replace(/\s/g, '') },
+      { key: 'sted',     val: CV.sted,     href: null },
+      { key: 'nettside', val: CV.nettside, href: 'https://' + CV.nettside },
+    ].forEach(k => {
+      if (!k.val) return;
+      $('contactCards').insertAdjacentHTML('beforeend', `
         <div class="cc">
           <div class="cc-ico"><svg width="15" height="15" viewBox="0 0 16 16" fill="none">${ccSvg[k.key]}</svg></div>
-          <div class="cc-label" data-ccl="${k.key}"></div>
-          <div class="cc-val">${k.href?`<a href="${k.href}">${k.val}</a>`:k.val}</div>
+          <div>
+            <div class="cc-label" data-ccl="${k.key}"></div>
+            <div class="cc-val">${k.href ? `<a href="${k.href}">${k.val}</a>` : k.val}</div>
+          </div>
         </div>`);
     });
 
     // Typewriter
-    let twPi=0,twCi=0,twDel=false,twTimer=null,twFr=[];
-    function twStart(fr){ clearTimeout(twTimer); twFr=fr; twPi=0; twCi=0; twDel=false; $('twText').textContent=''; twStep(); }
-    function twStep(){
-      const ph=twFr[twPi];
-      if(!twDel){ $('twText').textContent=ph.slice(0,++twCi); if(twCi===ph.length){twDel=true;twTimer=setTimeout(twStep,2000);return;} }
-      else{ $('twText').textContent=ph.slice(0,--twCi); if(twCi===0){twDel=false;twPi=(twPi+1)%twFr.length;} }
-      twTimer=setTimeout(twStep,twDel?40:80);
+    let twPi = 0, twCi = 0, twDel = false, twTimer = null, twFr = [];
+    function twStart(fr) { clearTimeout(twTimer); twFr = fr; twPi = 0; twCi = 0; twDel = false; $('twText').textContent = ''; twStep(); }
+    function twStep() {
+      const ph = twFr[twPi];
+      if (!twDel) {
+        $('twText').textContent = ph.slice(0, ++twCi);
+        if (twCi === ph.length) { twDel = true; twTimer = setTimeout(twStep, 2000); return; }
+      } else {
+        $('twText').textContent = ph.slice(0, --twCi);
+        if (twCi === 0) { twDel = false; twPi = (twPi + 1) % twFr.length; }
+      }
+      twTimer = setTimeout(twStep, twDel ? 40 : 80);
     }
 
-    // Kontaktskjema med Formspree
+    // Contact form (Formspree)
     $('fSend').addEventListener('click', async () => {
-      const u=CV.ui;
-      const navn=$('fNavn').value.trim();
-      const epost=$('fEpost').value.trim();
-      const emne=$('fEmne').value.trim();
-      const melding=$('fMelding').value.trim();
-      const msg=$('formMsg');
+      const u = CV.ui;
+      const navn    = $('fNavn').value.trim();
+      const epost   = $('fEpost').value.trim();
+      const emne    = $('fEmne').value.trim();
+      const melding = $('fMelding').value.trim();
+      const msg     = $('formMsg');
 
-      if (!CV.formspreeId) {
-        msg.className='form-msg err';
-        msg.textContent=t(u.ingenFormspree);
-        return;
-      }
-      if (!navn||!epost||!emne||!melding) {
-        msg.className='form-msg err';
-        msg.textContent=t(u.skjemaMangler);
-        return;
-      }
+      if (!CV.formspreeId) { msg.className = 'form-msg err'; msg.textContent = t(u.ingenFormspree); return; }
+      if (!navn || !epost || !emne || !melding) { msg.className = 'form-msg err'; msg.textContent = t(u.skjemaMangler); return; }
 
-      $('fSend').disabled=true;
-      $('fSend').textContent=t(u.senderMelding);
-      msg.className='form-msg';
+      $('fSend').disabled = true;
+      $('fSend').textContent = t(u.senderMelding);
+      msg.className = 'form-msg';
 
       try {
-        const res=await fetch(`https://formspree.io/f/${CV.formspreeId}`,{
-          method:'POST',
-          headers:{'Content-Type':'application/json','Accept':'application/json'},
-          body:JSON.stringify({name:navn,email:epost,subject:emne,message:melding}),
+        const res = await fetch(`https://formspree.io/f/${CV.formspreeId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+          body: JSON.stringify({ name: navn, email: epost, subject: emne, message: melding }),
         });
-        if(res.ok){
-          msg.className='form-msg ok';
-          msg.textContent=t(u.meldingSendt);
-          $('fNavn').value=''; $('fEpost').value=''; $('fEmne').value=''; $('fMelding').value='';
-        } else {
-          throw new Error('server error');
-        }
+        if (res.ok) {
+          msg.className = 'form-msg ok'; msg.textContent = t(u.meldingSendt);
+          $('fNavn').value = ''; $('fEpost').value = ''; $('fEmne').value = ''; $('fMelding').value = '';
+        } else { throw new Error(); }
       } catch {
-        msg.className='form-msg err';
-        msg.textContent=t(u.meldingFeil);
+        msg.className = 'form-msg err'; msg.textContent = t(u.meldingFeil);
       }
-      $('fSend').disabled=false;
-      set('fSend',t(u.sendKnapp));
+      $('fSend').disabled = false;
+      set('fSend', t(u.sendKnapp));
     });
 
     /* ── RENDER ── */
-    function render(){
-      document.documentElement.lang=lang;
-      document.title='CV – '+CV.navn;
-      const u=CV.ui;
+    function render() {
+      document.documentElement.lang = lang;
+      document.title = 'Stephan Teig — Film & Code';
+      const u = CV.ui;
 
-      set('sbRolle',            t(CV.tittel));
-      set('sbCvLink',           t(u.lastNedCV));
-      set('sbKontaktTittel',    t(u.kontaktTittel));
-      set('sbFerdigheterTittel',t(u.ferdigheterTittel));
-      set('sbSprakTittel',      t(u.sprakTittel));
-      set('sbFolgMeg',          t(u.folgMeg));
+      set('sbRolle',             t(CV.tittel));
+      set('sbCvLink',            t(u.lastNedCV));
+      set('sbKontaktTittel',     t(u.kontaktTittel));
+      set('sbFerdigheterTittel', t(u.ferdigheterTittel));
+      set('sbSprakTittel',       t(u.sprakTittel));
+      set('sbFolgMeg',           t(u.folgMeg));
 
-      htm('sbKontakt','');
-      [{svg:'<rect x="1" y="3" width="14" height="10" rx="1" stroke="#aaa" stroke-width="1.2"/><path d="M1 4l7 5 7-5" stroke="#aaa" stroke-width="1.2"/>',val:CV.epost,href:'mailto:'+CV.epost},
-       {svg:'<rect x="3" y="1" width="10" height="14" rx="2" stroke="#aaa" stroke-width="1.2"/><circle cx="8" cy="12" r="1" fill="#aaa"/>',val:CV.telefon,href:'tel:'+(CV.telefon||'').replace(/\s/g,'')},
-       {svg:'<path d="M8 1.5C5.5 1.5 3.5 3.5 3.5 6c0 3.5 4.5 8.5 4.5 8.5S12.5 9.5 12.5 6c0-2.5-2-4.5-4.5-4.5z" stroke="#aaa" stroke-width="1.2"/><circle cx="8" cy="6" r="1.5" stroke="#aaa" stroke-width="1.2"/>',val:CV.sted,href:null},
-      ].forEach(k=>{ if(!k.val) return;
-        $('sbKontakt').insertAdjacentHTML('beforeend',`<div class="sb-row"><svg class="sb-ico" viewBox="0 0 16 16" fill="none">${k.svg}</svg><div class="sb-val">${k.href?`<a href="${k.href}">${k.val}</a>`:k.val}</div></div>`);
+      htm('sbKontakt', '');
+      [
+        { svg: '<rect x="1" y="3" width="14" height="10" rx="1" stroke="rgba(136,136,168,.5)" stroke-width="1.2"/><path d="M1 4l7 5 7-5" stroke="rgba(136,136,168,.5)" stroke-width="1.2"/>',
+          val: CV.epost, href: 'mailto:' + CV.epost },
+        { svg: '<rect x="3" y="1" width="10" height="14" rx="2" stroke="rgba(136,136,168,.5)" stroke-width="1.2"/><circle cx="8" cy="12" r="1" fill="rgba(136,136,168,.5)"/>',
+          val: CV.telefon, href: 'tel:' + (CV.telefon || '').replace(/\s/g, '') },
+        { svg: '<path d="M8 1.5C5.5 1.5 3.5 3.5 3.5 6c0 3.5 4.5 8.5 4.5 8.5S12.5 9.5 12.5 6c0-2.5-2-4.5-4.5-4.5z" stroke="rgba(136,136,168,.5)" stroke-width="1.2"/><circle cx="8" cy="6" r="1.5" stroke="rgba(136,136,168,.5)" stroke-width="1.2"/>',
+          val: CV.sted, href: null },
+      ].forEach(k => {
+        if (!k.val) return;
+        $('sbKontakt').insertAdjacentHTML('beforeend', `
+          <div class="sb-row">
+            <svg class="sb-ico" viewBox="0 0 16 16" fill="none">${k.svg}</svg>
+            <div class="sb-val">${k.href ? `<a href="${k.href}">${k.val}</a>` : k.val}</div>
+          </div>`);
       });
 
-      document.querySelectorAll('[data-sk]').forEach((el,i)=>{ if(CV.ferdigheter[i]) el.textContent=t(CV.ferdigheter[i].navn); });
-      document.querySelectorAll('[data-ln]').forEach((el,i)=>{ const s=CV.sprak[i]; if(s) el.textContent=t(s.namn||s.navn); });
-      document.querySelectorAll('[data-stl]').forEach((el,i)=>{ if(CV.stats[i]) el.textContent=t(CV.stats[i].label); });
+      document.querySelectorAll('[data-sk]').forEach((el, i) => { if (CV.ferdigheter[i]) el.textContent = t(CV.ferdigheter[i].navn); });
+      document.querySelectorAll('[data-ln]').forEach((el, i) => { const s = CV.sprak[i]; if (s) el.textContent = t(s.namn || s.navn); });
+      document.querySelectorAll('[data-stl]').forEach((el, i) => { if (CV.stats[i]) el.textContent = t(CV.stats[i].label); });
 
-      // Nav
-      const nav=$('topNav');
-      nav.querySelectorAll('.nav-item').forEach(e=>e.remove());
-      const spacer=nav.querySelector('.nav-spacer');
-      const cur=document.querySelector('.page.active')?.id?.replace('page-','')||'home';
-      (CV.nav||[]).forEach(side=>{
-        const btn=mk('div'); btn.className='nav-item'+(side.id===cur?' active':'');
-        btn.textContent=t(side.label); btn.dataset.page=side.id;
-        btn.addEventListener('click',()=>goPage(side.id));
-        nav.insertBefore(btn,spacer);
+      // Top nav
+      const nav = $('topNav');
+      nav.querySelectorAll('.nav-item').forEach(e => e.remove());
+      const spacer = nav.querySelector('.nav-spacer');
+      const cur = document.querySelector('.page.active')?.id?.replace('page-', '') || 'home';
+      (CV.nav || []).forEach(side => {
+        const btn = mk('div');
+        btn.className = 'nav-item' + (side.id === cur ? ' active' : '');
+        btn.textContent = t(side.label); btn.dataset.page = side.id;
+        btn.addEventListener('click', () => goPage(side.id));
+        nav.insertBefore(btn, spacer);
       });
 
-      // Mob nav
-      htm('mobNavInner','');
-      const mobIcons={
-        home:'<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9.5L10 3l7 6.5V17a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z"/><path d="M7 18v-6h6v6"/></svg>',
-        resume:'<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="12" height="16" rx="1"/><path d="M7 7h6M7 10h6M7 13h4"/></svg>',
-        works:'<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="16" height="12" rx="1"/><path d="M8 9l5 3-5 3V9z" fill="currentColor" stroke="none"/></svg>',
-        contact:'<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 4h16v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4z"/><path d="M2 4l8 8 8-8"/></svg>',
+      // Mobile nav
+      htm('mobNavInner', '');
+      const mobIcons = {
+        home:    '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9.5L10 3l7 6.5V17a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z"/><path d="M7 18v-6h6v6"/></svg>',
+        resume:  '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="4" y="2" width="12" height="16" rx="1"/><path d="M7 7h6M7 10h6M7 13h4"/></svg>',
+        works:   '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="16" height="12" rx="1"/><path d="M8 9l5 3-5 3V9z" fill="currentColor" stroke="none"/></svg>',
+        contact: '<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 4h16v12a1 1 0 01-1 1H3a1 1 0 01-1-1V4z"/><path d="M2 4l8 8 8-8"/></svg>',
       };
-      (CV.nav||[]).forEach(side=>{
-        const btn=mk('div'); btn.className='mob-nav-item'+(side.id===cur?' active':'');
-        btn.innerHTML=(mobIcons[side.id]||'')+`<span>${t(side.label)}</span>`;
-        btn.addEventListener('click',()=>goPage(side.id));
+      (CV.nav || []).forEach(side => {
+        const btn = mk('div');
+        btn.className = 'mob-nav-item' + (side.id === cur ? ' active' : '');
+        btn.innerHTML = (mobIcons[side.id] || '') + `<span>${t(side.label)}</span>`;
+        btn.dataset.page = side.id;
+        btn.addEventListener('click', () => goPage(side.id));
         $('mobNavInner').appendChild(btn);
       });
 
       // Hero
-      set('heroHi',     t(u.heiJegEr));
-      const parts=CV.navn.split(' '); const en=parts.pop();
-      $('heroNavn').innerHTML=parts.join(' ')+' <b>'+en+'</b>';
+      set('heroLabel', t(u.heroLabel));
+      const parts = CV.navn.split(' '); const lastName = parts.pop(); const firstName = parts.join(' ');
+      $('heroNavn').innerHTML = `<span class="hero-first">${firstName}</span> <em class="hero-last">${lastName}</em>`;
       set('jegLager',   t(u.jegLager));
       set('heroBio',    t(CV.bio));
       set('btnSeProsj', t(u.seProsjekter));
@@ -917,73 +1086,93 @@
       set('resVerv',      t(u.verv));
       set('resUtdanning', t(u.utdanning));
 
-      function buildTl(items,cid){
-        htm(cid,'');
-        items.forEach((item,i)=>{
-          const last=i===items.length-1;
-          const tekst=t(item.tekst);
-          const sted=t(item.sted);
-          $(cid).insertAdjacentHTML('beforeend',`
-            <div class="tl-item">
-              <div class="tl-left"><div class="tl-dot"></div>${last?'':'<div class="tl-line"></div>'}</div>
-              <div class="tl-body">
-                <div class="tl-aar">${item.aar}</div>
-                <div class="tl-tittel">${t(item.tittel)}</div>
-                ${sted?`<div class="tl-sted">${sted}</div>`:''}
-                ${tekst?`<div class="tl-tekst">${tekst}</div>`:''}
-              </div>
-            </div>`);
+      set('contactHeadline', t(u.contactHeadline));
+      set('contactSub',      t(u.contactSub));
+
+      // Timeline builder
+      function buildTl(items, cid) {
+        htm(cid, '');
+        items.forEach((item, i) => {
+          const last  = i === items.length - 1;
+          const tekst = t(item.tekst);
+          const sted  = t(item.sted);
+          const el = mk('div'); el.className = 'tl-item fade-up';
+          el.style.transitionDelay = `${i * 55}ms`;
+          el.innerHTML = `
+            <div class="tl-left">
+              <div class="tl-dot"></div>
+              ${last ? '' : '<div class="tl-line"></div>'}
+            </div>
+            <div class="tl-body">
+              <div class="tl-aar">${item.aar}</div>
+              <div class="tl-tittel">${t(item.tittel)}</div>
+              ${sted  ? `<div class="tl-sted">${sted}</div>`   : ''}
+              ${tekst ? `<div class="tl-tekst">${tekst}</div>` : ''}
+            </div>`;
+          $(cid).appendChild(el);
+          io.observe(el);
         });
       }
       buildTl(CV.erfaring,  'erfaringListe');
       buildTl(CV.verv,      'vervListe');
       buildTl(CV.utdanning, 'utdanningListe');
 
-      // Prosjekt-kort tekst
-      kortRefs.forEach(({el,data:p})=>{
-        const rEl=el.querySelector('[data-wr]'); if(rEl) rEl.textContent=t(p.rolle);
-        const tEl=el.querySelector('[data-wtekst]'); if(tEl) tEl.textContent=t(p.tekst);
-        const bEl=el.querySelector('[data-wb]'); if(bEl) bEl.textContent=t(u.kommerSnart);
+      // Work card texts
+      kortRefs.forEach(({ el, data: p }) => {
+        const rEl = el.querySelector('[data-wr]');     if (rEl) rEl.textContent = t(p.rolle);
+        const tEl = el.querySelector('[data-wtekst]'); if (tEl) tEl.textContent = t(p.tekst);
+        const bEl = el.querySelector('[data-wb]');     if (bEl) bEl.textContent = t(u.kommerSnart);
       });
-      document.querySelectorAll('.wf-btn').forEach(btn=>{
-        const f=btn.dataset.fv;
-        btn.textContent=f==='alle'?t(u.alle):f.charAt(0).toUpperCase()+f.slice(1);
+      document.querySelectorAll('.wf-btn').forEach(btn => {
+        const f = btn.dataset.fv;
+        btn.textContent = f === 'alle' ? t(u.alle) : f;
       });
 
-      document.querySelectorAll('[data-ccl]').forEach(el=>{ el.textContent=t(u.kortLabels[el.dataset.ccl]); });
+      document.querySelectorAll('[data-ccl]').forEach(el => { el.textContent = t(u.kortLabels[el.dataset.ccl]); });
 
-      set('formTittel',        t(u.kontaktSideTittel));
-      $('fNavn').placeholder   =t(u.navnPlaceholder);
-      $('fEpost').placeholder  =t(u.epostPlaceholder);
-      $('fEmne').placeholder   =t(u.emnePlaceholder);
-      $('fMelding').placeholder=t(u.meldingPlaceholder);
-      set('fSend',             t(u.sendKnapp));
-      set('lbClose',           t(u.lukk));
+      set('formTittel',         t(u.kontaktSideTittel));
+      $('fNavn').placeholder    = t(u.navnPlaceholder);
+      $('fEpost').placeholder   = t(u.epostPlaceholder);
+      $('fEmne').placeholder    = t(u.emnePlaceholder);
+      $('fMelding').placeholder = t(u.meldingPlaceholder);
+      set('fSend',              t(u.sendKnapp));
+      set('lbClose',            t(u.lukk));
 
-      twStart(CV.fraser[lang]||CV.fraser['no']||[]);
+      twStart(CV.fraser[lang] || CV.fraser['no'] || []);
+
+      // Observe stat blocks
+      document.querySelectorAll('.stat.fade-up').forEach(el => io.observe(el));
     }
 
-    function goPage(name){
-      document.querySelectorAll('.nav-item,.mob-nav-item').forEach(n=>n.classList.toggle('active',n.dataset.page===name));
-      document.querySelectorAll('.page').forEach(p=>p.classList.toggle('active',p.id==='page-'+name));
-      const pe=document.querySelector('.pages'); if(pe) pe.scrollTop=0;
-      window.scrollTo(0,0);
+    function goPage(name) {
+      document.querySelectorAll('.nav-item,.mob-nav-item').forEach(n =>
+        n.classList.toggle('active', n.dataset.page === name));
+      document.querySelectorAll('.page').forEach(p =>
+        p.classList.toggle('active', p.id === 'page-' + name));
+      const pe = document.querySelector('.pages'); if (pe) pe.scrollTop = 0;
+      window.scrollTo(0, 0);
     }
-    window.goPage=goPage;
+    window.goPage = goPage;
 
-    $('btnNo').addEventListener('click',()=>{ if(lang==='no') return; lang='no'; $('btnNo').classList.add('active'); $('btnEn').classList.remove('active'); render(); });
-    $('btnEn').addEventListener('click',()=>{ if(lang==='en') return; lang='en'; $('btnEn').classList.add('active'); $('btnNo').classList.remove('active'); render(); });
+    $('btnNo').addEventListener('click', () => {
+      if (lang === 'no') return; lang = 'no';
+      $('btnNo').classList.add('active'); $('btnEn').classList.remove('active'); render();
+    });
+    $('btnEn').addEventListener('click', () => {
+      if (lang === 'en') return; lang = 'en';
+      $('btnEn').classList.add('active'); $('btnNo').classList.remove('active'); render();
+    });
 
-    function openLb(p){
-      let src='';
-      if(p.type==='youtube') src=`https://www.youtube.com/embed/${p.embed}?autoplay=1`;
-      if(p.type==='drive')   src=`https://drive.google.com/file/d/${p.embed}/preview`;
-      $('lbFrame').src=src; $('lightbox').classList.add('open'); document.body.style.overflow='hidden';
+    function openLb(p) {
+      let src = '';
+      if (p.type === 'youtube') src = `https://www.youtube.com/embed/${p.embed}?autoplay=1`;
+      if (p.type === 'drive')   src = `https://drive.google.com/file/d/${p.embed}/preview`;
+      $('lbFrame').src = src; $('lightbox').classList.add('open'); document.body.style.overflow = 'hidden';
     }
-    function closeLb(){ $('lightbox').classList.remove('open'); $('lbFrame').src=''; document.body.style.overflow=''; }
-    $('lbBd').addEventListener('click',closeLb);
-    $('lbClose').addEventListener('click',closeLb);
-    document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeLb(); });
+    function closeLb() { $('lightbox').classList.remove('open'); $('lbFrame').src = ''; document.body.style.overflow = ''; }
+    $('lbBd').addEventListener('click', closeLb);
+    $('lbClose').addEventListener('click', closeLb);
+    document.addEventListener('keydown', e => { if (e.key === 'Escape') closeLb(); });
 
     render();
   })();


### PR DESCRIPTION
## Summary

Complete visual redesign of `index.html` — new design system applied end-to-end while preserving all existing functionality (language toggle, lightbox, Formspree, mobile nav, PDF download, all external links).

### Design system applied
- **Palette:** violet `#7c5cfc` → pink `#d44fa8` → cyan `#4ae3d1` — coherent gradient + glow system throughout
- **Typography:** Instrument Serif italic (hero/display), Inter (UI/body), JetBrains Mono (labels, numerics, timestamps)
- **Background:** `#0b0b0f` with violet undertone + SVG fractalNoise grain overlay at 3.5% opacity
- **Texture:** Radial violet glow in hero, gradient skill bars (cyan → violet), glow on stat numbers and active avatar ring
- **Cards:** `border-radius: 12px` with hover glow ring; controls stay `border-radius: 4px`; filter chips are pill-shaped
- **`//` slash prefix** on all section headers (Montone reference)
- **Scroll-driven fade-up** via IntersectionObserver — timeline items stagger at 55ms, stats at 80ms

### Section changes
- **Hero:** `// film + code` cyan label → `Stephan` (Inter thin) + *`Teig`* (Instrument Serif italic, violet glow) → typewriter in pink → gradient CTA buttons
- **Resume:** End-credits timeline — JetBrains Mono years, current role dot glows violet, `//` section headers
- **Works:** 3-col grid (→ 2 → 1 responsive), gradient placeholder thumbnails for Drive/tech projects, `// in development` chip in cyan for in-progress work, Live ↗ / GitHub ↗ links for tech projects
- **Contact:** Instrument Serif italic headline, studio-style info cards with icon, violet focus ring on form inputs, gradient submit button

### Content updates (in `CV` object)
- Bio updated: age 18 (June 9, 2026), Studio Wallin lærling through summer 2028, sharpened language
- Premiere Pro removed; DaVinci Resolve → 90%; added Colour Grading, Sound Design, Content Production
- Studio Wallin entry expanded: foto, video, brand-arbeid, podcast-workflow, lærling note
- Stats: 15+ projects
- **New projects:** Trace (SVG logo animator, live at stephanteig.github.io/logo-animator/), Shotlist Planner (in dev → badge), Color Preview (published Obsidian plugin)

### Hard constraints respected
- `index.html` stays at repo root — no structure changes
- `Media/` folder untouched
- No build step — single self-contained file, CDN-only fonts
- `CV` object remains single source of truth for all content
- All existing functionality preserved

https://claude.ai/code/session_01Pd12GECy1qaaYvFantieAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd12GECy1qaaYvFantieAi)_