### PR TITLE
Oppdater CV-innhold: alder, nye prosjekter, github-lenke, stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,8 +160,11 @@ CV-/portfolio-nettside for **Stephan Teig**, hostet på GitHub Pages.
 | Reshoot Del 2 — Valg 2 | youtube | film | — |
 | TEDx Fredrikstad | youtube | foto | — |
 | MÆD Musikkvideo | youtube | film | — |
+| Red Bull Reklame | ingen | film | Ingen demo-lenke ennå |
+| Like Him — Kolberg Volleyball | youtube | film | **TODO: embed-ID mangler** |
+| Hvordan er det å gå på CIS Sarpsborg | youtube | film | **TODO: embed-ID mangler** |
 | Trace | ingen | tech | Har lenke + github |
-| Shotlist Planner | ingen | tech | badge: true, mangler github-lenke |
+| Shotlist Planner | ingen | tech | badge: true, har github-lenke |
 | Color Preview | ingen | tech | Obsidian-plugin, PR #12013 |
 
 ### Ferdigheter (sidebar)
@@ -188,17 +191,17 @@ CV-/portfolio-nettside for **Stephan Teig**, hostet på GitHub Pages.
 ### Stats (hero)
 
 - "7+" — Års jobberfaring
-- "15+" — Prosjekter *(oppdater når nye prosjekter legges til)*
+- "12" — Prosjekter *(oppdater når nye prosjekter legges til)*
 - "1.dan" — Jiu-Jitsu
 
 ---
 
 ## 8. Gjenstående oppgaver
 
-Se `cv-oppdateringer.md` i repo-roten for aktiv sjekkliste. Når en oppgave er fullført:
-1. Fjern haken-linjen fra `cv-oppdateringer.md` (eller hele oppgaven hvis seksjonen er ferdig).
-2. Oppdater relevant tabell/seksjon i denne CLAUDE.md hvis innholdsbildet endret seg.
-3. Når **alle** oppgaver i `cv-oppdateringer.md` er fullført, slett filen i samme PR.
+- **Like Him — Kolberg Volleyball**: erstatt `embed: "TODO_LEGG_INN_YOUTUBE_ID"` med riktig YouTube-ID.
+- **Hvordan er det å gå på CIS Sarpsborg**: erstatt `embed: "TODO_LEGG_INN_YOUTUBE_ID"` med riktig YouTube-ID.
+
+Når begge YouTube-ID-ene er lagt inn, oppdater prosjekttabellen i seksjon 7 til å fjerne **TODO**-notaten.
 
 ---
 
@@ -246,4 +249,4 @@ Ikke la denne filen råtne. En utdatert CLAUDE.md er verre enn ingen CLAUDE.md, 
 
 ---
 
-*Sist oppdatert: ved opprettelse. Husk å oppdatere dato eller fjerne denne linjen ved neste meningsfulle endring.*
+*Sist oppdatert: 2026-05-11 — beregnAlder(), 3 nye prosjekter, Shotlist Planner github-lenke, stats 12.*

--- a/index.html
+++ b/index.html
@@ -287,6 +287,7 @@
         type:   "ingen",
         filter: "tech",
         badge:  true,
+        github: "https://github.com/stephanteig/shotlist-planner",
       },
       {
         tittel: "Color Preview",

--- a/index.html
+++ b/index.html
@@ -12,6 +12,14 @@
        ✏️  REDIGER ALT HER — ingen annen fil trenger å endres
        ============================================================ -->
   <script>
+  function beregnAlder() {
+    const fodt = new Date(2008, 5, 9); // 9. juni 2008
+    const iDag = new Date();
+    let alder = iDag.getFullYear() - fodt.getFullYear();
+    if (iDag < new Date(iDag.getFullYear(), 5, 9)) alder--;
+    return alder;
+  }
+
   const CV = {
 
     // ── PERSONLIG INFO ──────────────────────────────────────────
@@ -28,8 +36,8 @@
     formspreeId: "mwvrraez",
 
     bio: {
-      no: "Fyller 18 den 9. juni 2026. VG2 Medieproduksjon på Glemmen VGS og lærling hos Studio Wallin i Fredrikstad — der jeg jobber med foto, video, brand og podkast frem til sommeren 2028. Lager kortfilmer, fargekorrigerer, designer verktøy og instruerer Ju-Jitsu. Trives best når kamera, kode og historiefortelling overlapper.",
-      en: "Turning 18 on June 9, 2026. VG2 Media Production at Glemmen VGS and apprentice at Studio Wallin in Fredrikstad — working across photo, video, brand and podcast through summer 2028. I make short films, grade colour, build tools, and teach Ju-Jitsu. Best when camera, code and storytelling overlap.",
+      no: `${beregnAlder()} år. VG2 Medieproduksjon på Glemmen VGS og lærling hos Studio Wallin i Fredrikstad — der jeg jobber med foto, video, brand og podkast frem til sommeren 2028. Lager kortfilmer, fargekorrigerer, designer verktøy og instruerer Ju-Jitsu. Trives best når kamera, kode og historiefortelling overlapper.`,
+      en: `${beregnAlder()} years old. VG2 Media Production at Glemmen VGS and apprentice at Studio Wallin in Fredrikstad — working across photo, video, brand and podcast through summer 2028. I make short films, grade colour, build tools, and teach Ju-Jitsu. Best when camera, code and storytelling overlap.`,
     },
 
     fraser: {

--- a/index.html
+++ b/index.html
@@ -250,6 +250,28 @@
         filter: "film",
       },
       {
+        tittel: "Red Bull Reklame",
+        rolle:  { no: "Film", en: "Film" },
+        type:   "ingen",
+        filter: "film",
+      },
+      // TODO: erstatt embed-ID når YouTube-video er lastet opp
+      {
+        tittel: "Like Him — Kolberg Volleyball",
+        rolle:  { no: "Film", en: "Film" },
+        type:   "youtube",
+        embed:  "TODO_LEGG_INN_YOUTUBE_ID",
+        filter: "film",
+      },
+      // TODO: erstatt embed-ID når YouTube-video er lastet opp
+      {
+        tittel: "Hvordan er det å gå på CIS Sarpsborg",
+        rolle:  { no: "Film", en: "Film" },
+        type:   "youtube",
+        embed:  "TODO_LEGG_INN_YOUTUBE_ID",
+        filter: "film",
+      },
+      {
         tittel: "Trace",
         rolle:  { no: "SVG logo-animatør", en: "SVG logo animator" },
         tekst:  { no: "Next.js 15 + TypeScript. Animer logoer fra SVG-filer med justerbar hastighet og stil.", en: "Next.js 15 + TypeScript. Animate logos from SVG files with adjustable speed and style." },

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
     stats: [
       { tall: "7+",    label: { no: "Års jobberfaring", en: "Years experience" } },
-      { tall: "15+",   label: { no: "Prosjekter",       en: "Projects"         } },
+      { tall: "12",    label: { no: "Prosjekter",       en: "Projects"         } },
       { tall: "1.dan", label: { no: "Jiu-Jitsu",        en: "Jiu-Jitsu"       } },
     ],
 


### PR DESCRIPTION
## Endringer

- **`beregnAlder()`** definert før `const CV = {` — bio bruker nå `${beregnAlder()}` via template literal for dynamisk aldersberegning basert på fødselsdato 09.06.2008.
- **3 nye filmprosjekter** lagt til etter MÆD Musikkvideo:
  - Red Bull Reklame (`type: "ingen"`, `filter: "film"`)
  - Like Him — Kolberg Volleyball (`type: "youtube"`, `filter: "film"`) — **TODO: embed-ID mangler**
  - Hvordan er det å gå på CIS Sarpsborg (`type: "youtube"`, `filter: "film"`) — **TODO: embed-ID mangler**
- **Shotlist Planner** — lagt til `github: "https://github.com/stephanteig/shotlist-planner"`.
- **Stats prosjektantall** oppdatert fra `"15+"` til `"12"` (teller prosjekter i arrayen).
- **CLAUDE.md** oppdatert: prosjekttabell, stats-snapshot, seksjon 8 med gjenstående YouTube-ID-oppgaver.

## Gjenstående (ikke i denne PR)

- YouTube-ID for "Like Him — Kolberg Volleyball" — legges inn av Stephan.
- YouTube-ID for "Hvordan er det å gå på CIS Sarpsborg" — legges inn av Stephan.

## Test

- Åpne `index.html` i nettleser og sjekk at alderen rendrer korrekt i bio.
- Verifiser at de 3 nye prosjektkortene vises under "film"-filteret.
- Sjekk at Shotlist Planner har GitHub-knapp.
- Sjekk at stats viser "12".

🤖 Generated with [Claude Code](https://claude.com/claude-code)