### PR TITLE
Legg til Respawn Østfold (prosjekt + verv)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Sidebar bruker `v5-farger-mørk.svg` via `.sb-logo`-klassen (CSS: `width: 75%; m
   tekst:  { no: "string", en: "string" },    // valgfri beskrivelse under tittel
   type:   "youtube" | "drive" | "ingen",     // bestemmer thumbnail og klikk-oppførsel
   embed:  "youtube-id | drive-fil-id",       // påkrevd hvis type !== "ingen"
-  filter: "film" | "foto" | "tech",          // bestemmer hvilken filter-chip kortet vises under
+  filter: "film" | "foto" | "tech" | "esport", // bestemmer hvilken filter-chip kortet vises under
   badge:  true,                              // valgfri — viser "// in development"-chip
   lenke:  "https://...",                     // ekstern lenke (gjør hele kortet klikkbart hvis ikke type=youtube/drive)
   github: "https://github.com/...",          // valgfri GitHub-lenke-knapp under tekst
@@ -173,6 +173,7 @@ Sidebar bruker `v5-farger-mørk.svg` via `.sb-logo`-klassen (CSS: `width: 75%; m
 
 | Tittel | Type | Filter | Notater |
 |---|---|---|---|
+| Respawn Østfold | ingen | esport | Lenke til turneringsside, kode-ikon thumbnail |
 | Et ekko av henne | drive | film | — |
 | Reshoot | youtube | film | — |
 | Reshoot Del 2 — Valg 1 | youtube | film | — |
@@ -197,6 +198,8 @@ Sidebar bruker `v5-farger-mørk.svg` via `.sb-logo`-klassen (CSS: `width: 75%; m
 | Lyddesign | 75 |
 | Innholdsproduksjon | 85 |
 | Fotografi | 70 |
+| OBS Studio | 85 |
+| Live produksjon | 80 |
 
 *(Premiere Pro er fjernet fra denne listen.)*
 
@@ -249,7 +252,7 @@ Når begge YouTube-ID-ene er lagt inn, oppdater prosjekttabellen i seksjon 7 til
 - **`type: "ingen"` + ingen `lenke`** = ikke-klikkbart kort (`.no-click`-klasse legges til automatisk i render). Det er OK for prosjekter som ennå ikke har en synlig demo.
 - **YouTube-ID er kun ID-en**, ikke hele URL-en (ikke `https://youtube.com/watch?v=abc`, kun `abc`).
 - **Drive-fil-ID** er strengen mellom `/d/` og `/view` i en Google Drive-URL.
-- **`filter`-feltet** må matche en av de eksisterende kategoriene (`film`, `foto`, `tech`) — eller ny kategori vil legges til som chip automatisk.
+- **`filter`-feltet** må matche en av de eksisterende kategoriene (`film`, `foto`, `tech`, `esport`) — eller ny kategori vil legges til som chip automatisk.
 - **Render-funksjonen kalles én gang per språkbytte**, så alle DOM-elementer regenereres. Ikke bind state til DOM-noder utenfor `CV`-objektet.
 - **`document.title`** er hardkodet til "Stephan Teig — Film & Code" i render-funksjonen. Endring av navn/tittel krever endring der.
 
@@ -268,4 +271,4 @@ Ikke la denne filen råtne. En utdatert CLAUDE.md er verre enn ingen CLAUDE.md, 
 
 ---
 
-*Sist oppdatert: 2026-05-13 — bio-frase fjernet, auto prosjektantall, logo i sidebar + favicon, favicon-ideer.md, design-brief.md, logo-asset-tabell.*
+*Sist oppdatert: 2026-06-02 — lagt til Respawn Østfold (prosjekt + verv), ny `esport`-filterkategori, OBS Studio + Live produksjon i ferdigheter, esport-frase i typewriter.*

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@
     },
 
     fraser: {
-      no: [ "kortfilmer.", "fargegradering.", "innhold som engasjerer.", "verktøy som hjelper." ],
-      en: [ "short films.", "colour grades.", "engaging content.", "tools that help." ],
+      no: [ "kortfilmer.", "fargegradering.", "innhold som engasjerer.", "verktøy som hjelper.", "esport-turneringer." ],
+      en: [ "short films.", "colour grades.", "engaging content.", "tools that help.", "esports tournaments." ],
     },
 
     stats: [
@@ -84,6 +84,8 @@
       { navn: { no: "Lyddesign",          en: "Sound design"       }, prosent: 75 },
       { navn: { no: "Innholdsproduksjon", en: "Content production" }, prosent: 85 },
       { navn: { no: "Fotografi",          en: "Photography"        }, prosent: 70 },
+      { navn: "OBS Studio",                                           prosent: 85 },
+      { navn: { no: "Live produksjon",    en: "Live production"    }, prosent: 80 },
     ],
 
     // ── SPRÅK ────────────────────────────────────────────────────
@@ -164,6 +166,15 @@
     // ── VERV ─────────────────────────────────────────────────────
     verv: [
       {
+        aar:    "2026",
+        tittel: { no: "Arrangør og kommentator", en: "Organizer and Commentator" },
+        sted:   "Respawn Østfold · Glemmen VGS, Fredrikstad",
+        tekst:  {
+          no: "Arrangerte MCSR Ranked Minecraft speedrun-turnering med cash prize og live stream. Ansvar for produksjon, promotering, sponsorarbeid og kommentator på Twitch.",
+          en: "Organized MCSR Ranked Minecraft speedrun tournament with cash prize and live stream. Handled production, promotion, sponsor outreach and commentating on Twitch.",
+        },
+      },
+      {
         aar:    "2025 –",
         tittel: { no: "Styreleder", en: "Board chair" },
         sted:   { no: "Ungdomsstyret, Sentrum Kampsport (SKS)", en: "Youth board, Sentrum Kampsport (SKS)" },
@@ -222,6 +233,20 @@
     // badge: true  → vis "// in development"-chip
     // lenke / github: eksterne lenker for tech-prosjekter
     prosjekter: [
+      // Respawn Østfold — added 2026
+      // Turneringsside: stephanteig.github.io/respawn-ostfold
+      // Twitch: twitch.tv/stephanteig
+      {
+        tittel: "Respawn Østfold",
+        rolle:  { no: "Esport-arrangør · Kommentator", en: "Esports Organizer · Commentator" },
+        tekst:  {
+          no: "MCSR Ranked Minecraft speedrun-turnering med cash prize, streamet live fra Glemmen VGS i Fredrikstad. Bracket-format, 1v1 online, kommentert på Twitch.",
+          en: "MCSR Ranked Minecraft speedrun tournament with cash prize, streamed live from Glemmen VGS in Fredrikstad. Bracket format, 1v1 online, commented on Twitch.",
+        },
+        type:   "ingen",
+        filter: "esport",
+        lenke:  "https://stephanteig.github.io/respawn-ostfold/",
+      },
       {
         tittel: "Et ekko av henne",
         rolle:  { no: "Film", en: "Film" },


### PR DESCRIPTION
## Endringer

Legger til **Respawn Østfold** (MCSR Ranked Minecraft speedrun-turnering med cash prize, streamet live fra Glemmen VGS) på CV-siden.

### `index.html` (kun `CV`-objektet — render-logikk urørt)
- **Prosjekt:** nytt kort øverst i `prosjekter` — `type: "ingen"`, ny `esport`-filterkategori (auto-generert chip), `lenke` til turneringssiden. Doc-kommentar over oppføringen.
- **Verv:** ny oppføring øverst — `2026`, "Arrangør og kommentator".
- **Ferdigheter:** OBS Studio (85) + Live produksjon (80).
- **Typewriter:** lagt til "esport-turneringer." / "esports tournaments." (substantivform så "Jeg lager ___" blir grammatisk riktig).
- Prosjektantall-stat oppdateres automatisk (12 → 13).

### `CLAUDE.md` (vedlikehold, samme PR)
- `esport` lagt til i filterkategori-listen (seksjon 6 + 10).
- Prosjekt- og ferdighetstabell (seksjon 7) oppdatert.
- "Sist oppdatert"-linje.

## Avvik fra instruks-spec (CV_RESPAWN_UPDATE.md)
Repoets egen `CLAUDE.md` er single source of truth og overstyrer der det er konflikt:
- **Thumbnail utelatt:** spec sin `og-image.png` og fallback `logo.png` gir begge 404 på live-siden. Kortet bruker derfor kode-ikon-gradienten (ingen ødelagt bilde, ingen render-endring). Kortet er fortsatt klikkbart via `lenke`.
- **`ferdigheter`-skjema:** tilpasset reelt skjema `{ navn, prosent }` (ikke `nivaa`).
- **Filter-knapp:** auto-generert fra data — ingen manuell markup nødvendig.
- **Stats:** prosjektantall auto-beregnet — ingen manuell endring.
- **Typewriter-frase:** omformulert til substantivform.

## Verifisering
- Begge `<script>`-blokker kompilerer feilfritt (`new Function`).
- `prosjekter.length` = 13, stats auto = 13.
- Filtre: esport, film, foto, tech.
- Verv[0] = 2026 Arrangør og kommentator.
- Ferdigheter: 9 totalt, OBS Studio 85% + Live produksjon 80%.
- `fraser` no/en balansert (5/5).
- Ingen eksisterende oppføringer fjernet/endret; fortsatt én `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)