### PR TITLE
Fiks tre prosjektkort med manglende video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,9 @@ Sidebar bruker `v5-farger-mørk.svg` via `.sb-logo`-klassen (CSS: `width: 75%; m
 | Reshoot Del 2 — Valg 2 | youtube | film | — |
 | TEDx Fredrikstad | youtube | foto | — |
 | MÆD Musikkvideo | youtube | film | — |
-| Red Bull Reklame | ingen | film | Ingen demo-lenke ennå |
-| Like Him — Kolberg Volleyball | youtube | film | **TODO: embed-ID mangler** |
-| Hvordan er det å gå på CIS Sarpsborg | youtube | film | **TODO: embed-ID mangler** |
+| Red Bull Reklame | drive | film | — |
+| Like Him — Kolberg Volleyball | drive | film | — |
+| Hvordan er det å gå på CIS Sarpsborg | drive | film | — |
 | Trace | ingen | tech | Har lenke + github |
 | Shotlist Planner | ingen | tech | badge: true, har github-lenke |
 | Color Preview | ingen | tech | Obsidian-plugin, PR #12013 |
@@ -220,10 +220,7 @@ Sidebar bruker `v5-farger-mørk.svg` via `.sb-logo`-klassen (CSS: `width: 75%; m
 
 ## 8. Gjenstående oppgaver
 
-- **Like Him — Kolberg Volleyball**: erstatt `embed: "TODO_LEGG_INN_YOUTUBE_ID"` med riktig YouTube-ID.
-- **Hvordan er det å gå på CIS Sarpsborg**: erstatt `embed: "TODO_LEGG_INN_YOUTUBE_ID"` med riktig YouTube-ID.
-
-Når begge YouTube-ID-ene er lagt inn, oppdater prosjekttabellen i seksjon 7 til å fjerne **TODO**-notaten.
+Ingen kjente gjenstående oppgaver.
 
 ---
 
@@ -271,4 +268,4 @@ Ikke la denne filen råtne. En utdatert CLAUDE.md er verre enn ingen CLAUDE.md, 
 
 ---
 
-*Sist oppdatert: 2026-06-02 — lagt til Respawn Østfold (prosjekt + verv), ny `esport`-filterkategori, OBS Studio + Live produksjon i ferdigheter, esport-frase i typewriter.*
+*Sist oppdatert: 2026-07-07 — Google Drive-embeds lagt inn for Kolberg Volleyball, CIS Sarpsborg og Red Bull Reklame; begge TODO-embed-IDer fjernet, ingen gjenstående oppgaver.*

--- a/index.html
+++ b/index.html
@@ -297,23 +297,22 @@
         tittel: "Red Bull Reklame",
         rolle:  { no: "Film · Regi", en: "Film · Director" },
         tekst:  { no: "Reklamekonsept i Red Bull sin stil — opptak, klipp og fargegradering.", en: "Advertisement concept in Red Bull's style — footage, editing and colour grading." },
-        type:   "ingen",
+        type:   "drive",
+        embed:  "1Ru1S7h7hhjcxhzlD99xoBmEOJlJRQSdx",
         filter: "film",
       },
-      // TODO: erstatt embed-ID når YouTube-video er lastet opp
       {
         tittel: "Like Him — Kolberg Volleyball",
         rolle:  { no: "Film", en: "Film" },
-        type:   "youtube",
-        embed:  "TODO_LEGG_INN_YOUTUBE_ID",
+        type:   "drive",
+        embed:  "1jV57ZGSrkjeDjnRASnaEHPV5FuZrUOXf",
         filter: "film",
       },
-      // TODO: erstatt embed-ID når YouTube-video er lastet opp
       {
         tittel: "Hvordan er det å gå på CIS Sarpsborg",
         rolle:  { no: "Film", en: "Film" },
-        type:   "youtube",
-        embed:  "TODO_LEGG_INN_YOUTUBE_ID",
+        type:   "drive",
+        embed:  "1kXr3ZOZc7MiXJmmomOR84baHu4VsOnLY",
         filter: "film",
       },
       {


### PR DESCRIPTION
## Summary
- Kolberg Volleyball og CIS Sarpsborg hadde TODO-placeholder-IDer (brukket lightbox) — begge har nå Google Drive-embeds
- Red Bull Reklame manglet video helt (type: "ingen") — har nå et Google Drive-embed
- Alle tre bruker samme drive-format som "Et ekko av henne"
- CLAUDE.md oppdatert: prosjekttabell og "Gjenstående oppgaver" reflekterer at TODOene er løst

## Test plan
- [x] `node --check` på script-innholdet i index.html — gyldig JS
- [x] Drive-type håndteres av eksisterende lightbox-logikk (ingen render-endringer nødvendig)
- [ ] Åpne siden i nettleser og bekreft at alle tre kort spiller av riktig Drive-video i lightboxen

🤖 Generated with [Claude Code](https://claude.com/claude-code)