### PR TITLE
Oppdater utdanningsstatus og bio — VG2 fullført, nå i læretid

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
     formspreeId: "mwvrraez",
 
     bio: {
-      no: `${beregnAlder()} år gammel, VG2-elev på Glemmen VGS og lærling hos Studio Wallin i Fredrikstad — jobber med foto, video, brand og podkast. Lager kortfilmer, fargekorrigerer, designer verktøy og instruerer Ju-Jitsu. Trives best når kamera, kode og historiefortelling møtes.`,
-      en: `${beregnAlder()} years old, VG2 student at Glemmen VGS and apprentice at Studio Wallin in Fredrikstad — working across photo, video, brand and podcast. I make short films, grade colour, build tools, and teach Ju-Jitsu. Best when camera, code and storytelling meet.`,
+      no: `${beregnAlder()} år gammel lærling i innholdsproduksjon hos Studio Wallin i Fredrikstad — jobber med foto, video, brand og podkast. Lager kortfilmer, fargekorrigerer, designer verktøy og instruerer Ju-Jitsu. Trives best når kamera, kode og historiefortelling møtes.`,
+      en: `${beregnAlder()} years old, apprentice content producer at Studio Wallin in Fredrikstad — working across photo, video, brand and podcast. I make short films, grade colour, build tools, and teach Ju-Jitsu. Best when camera, code and storytelling meet.`,
     },
 
     fraser: {
@@ -212,7 +212,7 @@
         aar:    "2024 – 2026",
         tittel: { no: "Informasjonsteknologi og medieproduksjon", en: "IT and Media Production" },
         sted:   "Glemmen videregående skole",
-        tekst:  { no: "VG1 med høyt snitt. Nå VG2 med fokus på film, redigering og produksjon.", en: "VG1 with high GPA. Now VG2 focusing on film, editing and production." },
+        tekst:  { no: "VG1 med høyt snitt. VG2 fullført våren 2026 med fokus på film, redigering og produksjon. Nå i læretid hos Studio Wallin.", en: "VG1 with high GPA. VG2 completed spring 2026, focusing on film, editing and production. Now an apprentice at Studio Wallin." },
       },
       {
         aar:    "2019 – 2024",


### PR DESCRIPTION
## Endringer

- Bio (no/en): fjernet "VG2-elev"-status, nå "lærling i innholdsproduksjon"
- Utdanning (Glemmen): VG2 markert som fullført våren 2026, ny linje om læretid hos Studio Wallin

Ingen andre endringer i index.html.